### PR TITLE
Fix watch synchronization bug

### DIFF
--- a/Shared/SharedData.swift
+++ b/Shared/SharedData.swift
@@ -30,7 +30,7 @@ class SharedData: NSObject, WCSessionDelegate, ObservableObject {
     }
 
     func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
-        if let listaRecebida = applicationContext["exercicios"] as? [String] {
+        if let listaRecebida = applicationContext["exercises"] as? [String] {
             DispatchQueue.main.async {
                 self.list = listaRecebida
             }

--- a/iWorkout Watch App/ContentView.swift
+++ b/iWorkout Watch App/ContentView.swift
@@ -21,16 +21,21 @@ struct ContentView: View {
                 Text("Descanso: \(tempoDescanso)s")
                     .font(.title2)
             } else {
-                Text(shared.list[indiceAtual])
-                    .font(.headline)
-                    .padding()
-                Button("Próximo") {
-                    if indiceAtual < shared.list.count - 1 {
-                        indiceAtual += 1
-                        startDescanso()
+                if shared.list.indices.contains(indiceAtual) {
+                    Text(shared.list[indiceAtual])
+                        .font(.headline)
+                        .padding()
+                    Button("Próximo") {
+                        if indiceAtual < shared.list.count - 1 {
+                            indiceAtual += 1
+                            startDescanso()
+                        }
                     }
+                    .padding(.top, 10)
+                } else {
+                    Text("Nenhum exercício")
+                        .padding()
                 }
-                .padding(.top, 10)
             }
         }
         .onAppear {


### PR DESCRIPTION
## Summary
- unify context key for workout list (`exercises`)
- avoid crash on watch when list is empty

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68408eb7e0d88331bc2083c3a8c26d94