### PR TITLE
Fix watch data sync on session activation

### DIFF
--- a/Shared/SharedData.swift
+++ b/Shared/SharedData.swift
@@ -26,7 +26,11 @@ class SharedData: NSObject, WCSessionDelegate, ObservableObject {
     }
 
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
-        // nada aqui
+        #if os(iOS)
+        if activationState == .activated {
+            enviarLista(list)
+        }
+        #endif
     }
 
     func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {


### PR DESCRIPTION
## Summary
- ensure WCSession sends the latest exercise list when it becomes active on iOS

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_684091ee49848331bc8deb82c9438cbf