### PR TITLE
Add persistent storage for exercise list

### DIFF
--- a/iWorkout/ExerciseModel.swift
+++ b/iWorkout/ExerciseModel.swift
@@ -7,18 +7,43 @@
 
 import Foundation
 
+// Key used to persist the exercises on the device
+private let exercisesKey = "savedExercises"
+
 class ExerciseModel: ObservableObject {
-    @Published var list: [String] = ["Agachamento", "Flexão", "Abdominal", "Levantamento Terra"]
-    
-    init() {
-            // Sempre que a lista mudar, envie pro Watch
+    // Published list of exercises. Whenever it's updated, we persist and
+    // send the new list to the watch.
+    @Published var list: [String] = [] {
+        didSet {
+            saveExercises()
             SharedData.shared.list = list
             SharedData.shared.enviarLista(list)
         }
+    }
 
-        func adicionarExercicio(_ nome: String) {
-            list.append(nome)
-            SharedData.shared.enviarLista(list)
+    init() {
+        loadExercises()
+    }
+
+    /// Adds a new exercise to the list
+    func adicionarExercicio(_ nome: String) {
+        list.append(nome)
+    }
+
+    /// Loads the exercises from UserDefaults or populates with a default list
+    private func loadExercises() {
+        if let data = UserDefaults.standard.data(forKey: exercisesKey),
+           let saved = try? JSONDecoder().decode([String].self, from: data) {
+            list = saved
+        } else {
+            list = ["Agachamento", "Flexão", "Abdominal", "Levantamento Terra"]
         }
+    }
 
+    /// Saves the current exercises list to UserDefaults
+    private func saveExercises() {
+        if let data = try? JSONEncoder().encode(list) {
+            UserDefaults.standard.set(data, forKey: exercisesKey)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- store user's exercise list in `UserDefaults`
- sync data to the watch and save whenever list changes

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a5d841e4833197515cc1731f992e