### PR TITLE
Persist exercise list

### DIFF
--- a/iWorkout/ExerciseModel.swift
+++ b/iWorkout/ExerciseModel.swift
@@ -8,13 +8,17 @@
 import Foundation
 
 class ExerciseModel: ObservableObject {
-    @Published var list: [Exercise] = Exercise.exemplo {
+    private static let storageKey = "exerciseList"
+
+    @Published var list: [Exercise] = [] {
         didSet {
+            saveList()
             enviarListaParaWatch()
         }
     }
 
     init() {
+        loadList()
         enviarListaParaWatch()
     }
 
@@ -27,5 +31,20 @@ class ExerciseModel: ObservableObject {
         let nomes = list.map { $0.name }
         SharedData.shared.list = nomes
         SharedData.shared.enviarLista(nomes)
+    }
+
+    private func saveList() {
+        if let data = try? JSONEncoder().encode(list) {
+            UserDefaults.standard.set(data, forKey: Self.storageKey)
+        }
+    }
+
+    private func loadList() {
+        if let data = UserDefaults.standard.data(forKey: Self.storageKey),
+           let saved = try? JSONDecoder().decode([Exercise].self, from: data) {
+            list = saved
+        } else {
+            list = Exercise.exemplo
+        }
     }
 }


### PR DESCRIPTION
## Summary
- save the exercise list to user defaults
- load saved exercises on init

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6840c06683cc8331bc08feb62ff5380d