### PR TITLE
Update timer sync behavior

### DIFF
--- a/iWorkout/Views/ExerciseDetailView.swift
+++ b/iWorkout/Views/ExerciseDetailView.swift
@@ -32,7 +32,13 @@ struct ExerciseDetailView: View {
             }
         }
         .navigationTitle("Editar Exercício")
+        .onAppear {
+            // Initialize the picker with the current value from the model
+            durationInSeconds = exercise.restDuration
+        }
         .onDisappear {
+            // Persist any changes back to the underlying Exercise
+            exercise.restDuration = durationInSeconds
             model.enviarListaParaWatch()
         }
     }


### PR DESCRIPTION
## Summary
- initialize timer picker with existing rest duration
- persist new duration when leaving the detail view

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6841082de43c8331be148305fa4dae01