### PR TITLE
Add localization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ Open `iWorkout.xcodeproj` in Xcode (version 14 or later recommended). Build and 
 
 The project currently lacks tests and documentation. Adding unit tests, improving error handling, and expanding the rest timer features would be valuable enhancements.
 
+## Localization
+
+The UI strings are defined using `LocalizedStringKey` so the app can be translated.
+English is the base language and Brazilian Portuguese translations live under `*.lproj/Localizable.strings` in
+each target's `Resources` folder. Add additional languages by creating a new
+`<language>.lproj` directory with a `Localizable.strings` file containing the
+desired translations.
+

--- a/Shared/UIComponents/CountdownTimerPicker.swift
+++ b/Shared/UIComponents/CountdownTimerPicker.swift
@@ -40,19 +40,19 @@ struct CountdownTimerPicker: View {
 
     var body: some View {
         HStack {
-            Picker("Horas", selection: hoursBinding) {
+            Picker("Hours", selection: hoursBinding) {
                 ForEach(0..<24, id: \.self) { Text("\($0)h").tag($0) }
             }
             .frame(maxWidth: .infinity)
             .clipped()
 
-            Picker("Minutos", selection: minutesBinding) {
+            Picker("Minutes", selection: minutesBinding) {
                 ForEach(0..<60, id: \.self) { Text("\($0)m").tag($0) }
             }
             .frame(maxWidth: .infinity)
             .clipped()
 
-            Picker("Segundos", selection: secondsBinding) {
+            Picker("Seconds", selection: secondsBinding) {
                 ForEach(0..<60, id: \.self) { Text("\($0)s").tag($0) }
             }
             .frame(maxWidth: .infinity)

--- a/iWorkout Watch App/Resources/en.lproj/Localizable.strings
+++ b/iWorkout Watch App/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,17 @@
+"My Workouts" = "My Workouts";
+"You haven't added exercises yet" = "You haven't added exercises yet";
+"New Ex. %d" = "New Ex. %d";
+"Delete exercise?" = "Delete exercise?";
+"Delete" = "Delete";
+"Cancel" = "Cancel";
+"Rest" = "Rest";
+"Rest: %llds" = "Rest: %llds";
+"Next" = "Next";
+"No exercise" = "No exercise";
+"Name" = "Name";
+"Sets" = "Sets";
+"%d sets" = "%d sets";
+"Edit Exercise" = "Edit Exercise";
+"Hours" = "Hours";
+"Minutes" = "Minutes";
+"Seconds" = "Seconds";

--- a/iWorkout Watch App/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout Watch App/Resources/pt.lproj/Localizable.strings
@@ -1,0 +1,17 @@
+"My Workouts" = "Meus Treinos";
+"You haven't added exercises yet" = "Você ainda não adicionou exercícios";
+"New Ex. %d" = "Novo Ex. %d";
+"Delete exercise?" = "Excluir exercício?";
+"Delete" = "Excluir";
+"Cancel" = "Cancelar";
+"Rest" = "Descanso";
+"Rest: %llds" = "Descanso: %llds";
+"Next" = "Próximo";
+"No exercise" = "Nenhum exercício";
+"Name" = "Nome";
+"Sets" = "Séries";
+"%d sets" = "%d séries";
+"Edit Exercise" = "Editar Exercício";
+"Hours" = "Horas";
+"Minutes" = "Minutos";
+"Seconds" = "Segundos";

--- a/iWorkout Watch App/Workout/Views/ContentView.swift
+++ b/iWorkout Watch App/Workout/Views/ContentView.swift
@@ -13,19 +13,19 @@ struct ContentView: View {
     var body: some View {
         VStack {
             if viewModel.showingRest {
-                Text("Descanso: \(viewModel.restTime)s")
+                Text("Rest: \(viewModel.restTime)s")
                     .font(.title2)
             } else {
                 if viewModel.shared.list.indices.contains(viewModel.currentIndex) {
                     Text(viewModel.shared.list[viewModel.currentIndex])
                         .font(.headline)
                         .padding()
-                    Button("Próximo") {
+                    Button("Next") {
                         viewModel.nextExercise()
                     }
                     .padding(.top, 10)
                 } else {
-                    Text("Nenhum exercício")
+                    Text("No exercise")
                         .padding()
                 }
             }

--- a/iWorkout/Exercises/Views/ContentView.swift
+++ b/iWorkout/Exercises/Views/ContentView.swift
@@ -32,7 +32,7 @@ struct ContentView: View {
         NavigationView {
             List {
                 if model.list.isEmpty {
-                    Text("Você ainda não adicionou exercícios")
+                    Text("You haven't added exercises yet")
                         .foregroundColor(.secondary)
                         .frame(maxWidth: .infinity, alignment: .center)
                 } else {
@@ -47,17 +47,21 @@ struct ContentView: View {
             }
             .toolbar {
                 Button {
-                    model.addExercise("Novo Ex. \(model.list.count + 1)")
+                    let title = String(
+                        format: NSLocalizedString("New Ex. %d", comment: "Default exercise name"),
+                        model.list.count + 1
+                    )
+                    model.addExercise(title)
                 } label: {
                     Image(systemName: "plus")
                 }
             }
-            .navigationTitle("Meus Treinos")
-            .alert("Excluir exercício?", isPresented: $showDeleteConfirm, presenting: exerciseToDelete) { exercise in
-                Button("Excluir", role: .destructive) {
+            .navigationTitle("My Workouts")
+            .alert("Delete exercise?", isPresented: $showDeleteConfirm, presenting: exerciseToDelete) { exercise in
+                Button("Delete", role: .destructive) {
                     model.removeExercise(exercise)
                 }
-                Button("Cancelar", role: .cancel) { }
+                Button("Cancel", role: .cancel) { }
             }
 
         }
@@ -84,7 +88,7 @@ struct ExerciseRow: View {
             Button(role: .destructive) {
                 onDelete()
             } label: {
-                Label("Excluir", systemImage: "trash")
+                Label("Delete", systemImage: "trash")
             }
         }
     }

--- a/iWorkout/Exercises/Views/ExerciseDetailView.swift
+++ b/iWorkout/Exercises/Views/ExerciseDetailView.swift
@@ -15,23 +15,23 @@ struct ExerciseDetailView: View {
 
     var body: some View {
         Form {
-            Section("Nome") {
-                TextField("Nome", text: $exercise.name)
+            Section("Name") {
+                TextField("Name", text: $exercise.name)
                     .autocorrectionDisabled(false)
             }
-            Section("Séries") {
+            Section("Sets") {
                 Stepper(value: $exercise.sets, in: 1...10) {
-                    Text("\(exercise.sets) séries")
+                    Text("\(exercise.sets) sets")
                 }
             }
-            Section("Descanso") {
+            Section("Rest") {
                 CountdownTimerPicker(duration: $durationInSeconds)
                                 .frame(maxWidth: .infinity)
                                 .clipped()
                                 .padding(.horizontal)
             }
         }
-        .navigationTitle("Editar Exercício")
+        .navigationTitle("Edit Exercise")
         .onAppear {
             // Initialize the picker with the current value from the model
             durationInSeconds = exercise.restDuration

--- a/iWorkout/Resources/en.lproj/Localizable.strings
+++ b/iWorkout/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,17 @@
+"My Workouts" = "My Workouts";
+"You haven't added exercises yet" = "You haven't added exercises yet";
+"New Ex. %d" = "New Ex. %d";
+"Delete exercise?" = "Delete exercise?";
+"Delete" = "Delete";
+"Cancel" = "Cancel";
+"Rest" = "Rest";
+"Rest: %llds" = "Rest: %llds";
+"Next" = "Next";
+"No exercise" = "No exercise";
+"Name" = "Name";
+"Sets" = "Sets";
+"%d sets" = "%d sets";
+"Edit Exercise" = "Edit Exercise";
+"Hours" = "Hours";
+"Minutes" = "Minutes";
+"Seconds" = "Seconds";

--- a/iWorkout/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout/Resources/pt.lproj/Localizable.strings
@@ -1,0 +1,17 @@
+"My Workouts" = "Meus Treinos";
+"You haven't added exercises yet" = "Você ainda não adicionou exercícios";
+"New Ex. %d" = "Novo Ex. %d";
+"Delete exercise?" = "Excluir exercício?";
+"Delete" = "Excluir";
+"Cancel" = "Cancelar";
+"Rest" = "Descanso";
+"Rest: %llds" = "Descanso: %llds";
+"Next" = "Próximo";
+"No exercise" = "Nenhum exercício";
+"Name" = "Nome";
+"Sets" = "Séries";
+"%d sets" = "%d séries";
+"Edit Exercise" = "Editar Exercício";
+"Hours" = "Horas";
+"Minutes" = "Minutos";
+"Seconds" = "Segundos";


### PR DESCRIPTION
## Summary
- update README's localization details
- switch default strings to English
- rework Localizable.strings files to use English keys
- translate iOS and watchOS screens to English

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841e5f18c9483318d2e5f305b42df57