### PR TITLE
Update timer picker units

### DIFF
--- a/Shared/UIComponents/CountdownTimerPicker.swift
+++ b/Shared/UIComponents/CountdownTimerPicker.swift
@@ -41,22 +41,25 @@ struct CountdownTimerPicker: View {
     var body: some View {
         HStack {
             Picker("Hours", selection: hoursBinding) {
-                ForEach(0..<24, id: \.self) { Text("\($0)h").tag($0) }
+                ForEach(0..<24, id: \.self) { Text("\($0)").tag($0) }
             }
             .frame(maxWidth: .infinity)
             .clipped()
+            Text("Hours")
 
             Picker("Minutes", selection: minutesBinding) {
-                ForEach(0..<60, id: \.self) { Text("\($0)m").tag($0) }
+                ForEach(0..<60, id: \.self) { Text("\($0)").tag($0) }
             }
             .frame(maxWidth: .infinity)
             .clipped()
+            Text("Minutes")
 
             Picker("Seconds", selection: secondsBinding) {
-                ForEach(0..<60, id: \.self) { Text("\($0)s").tag($0) }
+                ForEach(0..<60, id: \.self) { Text("\($0)").tag($0) }
             }
             .frame(maxWidth: .infinity)
             .clipped()
+            Text("Seconds")
         }
         .pickerStyle(.wheel)
     }


### PR DESCRIPTION
## Summary
- update `CountdownTimerPicker` so picker wheels show only numbers
- display translated unit labels (`Hours`, `Minutes`, `Seconds`) next to each picker

## Testing
- `swiftc -version`
- `swiftc -parse-as-library Shared/UIComponents/CountdownTimerPicker.swift -o /tmp/test.o` *(fails: no such module SwiftUI)*

------
https://chatgpt.com/codex/tasks/task_e_6842480848648331b9806231cfe0ff90