### PR TITLE
Fix watch workout layout with multi-step selection

### DIFF
--- a/iWorkout Watch App/Resources/en.lproj/Localizable.strings
+++ b/iWorkout Watch App/Resources/en.lproj/Localizable.strings
@@ -18,3 +18,5 @@
 "Edit Style" = "Edit Style";
 "Edit Session" = "Edit Session";
 "New Exercise" = "New Exercise";
+"Sessions" = "Sessions";
+"Workouts" = "Workouts";

--- a/iWorkout Watch App/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout Watch App/Resources/pt.lproj/Localizable.strings
@@ -18,3 +18,5 @@
 "Edit Style" = "Editar Estilo";
 "Edit Session" = "Editar Sessão";
 "New Exercise" = "Novo Exercício";
+"Sessions" = "Divisões";
+"Workouts" = "Treinos";

--- a/iWorkout Watch App/Workout/ViewModels/WatchWorkoutViewModel.swift
+++ b/iWorkout Watch App/Workout/ViewModels/WatchWorkoutViewModel.swift
@@ -3,10 +3,10 @@ import SwiftUI
 import Combine
 
 class WatchWorkoutViewModel: ObservableObject {
-    @Published var styleIndex: Int = 0 {
+    @Published var styleIndex: Int {
         didSet { resetProgress() }
     }
-    @Published var sessionIndex: Int = 0 {
+    @Published var sessionIndex: Int {
         didSet { resetProgress() }
     }
     @Published var currentIndex: Int = 0
@@ -17,12 +17,18 @@ class WatchWorkoutViewModel: ObservableObject {
     private var timer: Timer?
     private var cancellable: AnyCancellable?
 
-    init() {
+    init(styleIndex: Int, sessionIndex: Int) {
+        self.styleIndex = styleIndex
+        self.sessionIndex = sessionIndex
         // forward updates from SharedData so the view refreshes when
         // the exercise list changes
         cancellable = shared.objectWillChange.sink { [weak self] _ in
             self?.objectWillChange.send()
         }
+    }
+
+    convenience init() {
+        self.init(styleIndex: 0, sessionIndex: 0)
     }
 
     func resetProgress() {

--- a/iWorkout Watch App/Workout/Views/ContentView.swift
+++ b/iWorkout Watch App/Workout/Views/ContentView.swift
@@ -1,49 +1,10 @@
-//
-//  ContentView.swift
-//  iWorkout Watch App
-//
-//  Created by João Anelli on 6/3/25.
-//
-
 import SwiftUI
 
+/// Root view hosting the navigation stack on watchOS
 struct ContentView: View {
-    @StateObject private var viewModel = WatchWorkoutViewModel()
-    
     var body: some View {
-        VStack {
-            Picker("Style", selection: $viewModel.styleIndex) {
-                ForEach(viewModel.shared.styles.indices, id: \.self) { idx in
-                    Text(viewModel.shared.styles[idx].name).tag(idx)
-                }
-            }
-            Picker("Session", selection: $viewModel.sessionIndex) {
-                if viewModel.shared.styles.indices.contains(viewModel.styleIndex) {
-                    let style = viewModel.shared.styles[viewModel.styleIndex]
-                    ForEach(style.sessions.indices, id: \.self) { idx in
-                        Text(style.sessions[idx].name).tag(idx)
-                    }
-                }
-            }
-
-            if viewModel.showingRest {
-                Text("Rest: \(viewModel.restTime)s")
-                    .font(.title2)
-            } else {
-                if let session = viewModel.currentSession,
-                   session.exercises.indices.contains(viewModel.currentIndex) {
-                    Text(session.exercises[viewModel.currentIndex].name)
-                        .font(.headline)
-                        .padding()
-                    Button("Next") {
-                        viewModel.nextExercise()
-                    }
-                    .padding(.top, 10)
-                } else {
-                    Text("No exercise")
-                        .padding()
-                }
-            }
+        NavigationStack {
+            StyleListView()
         }
     }
 }

--- a/iWorkout Watch App/Workout/Views/SessionListView.swift
+++ b/iWorkout Watch App/Workout/Views/SessionListView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Lists sessions for the chosen workout style
+struct SessionListView: View {
+    let styleIndex: Int
+    @ObservedObject var shared = SharedData.shared
+
+    var body: some View {
+        let style = shared.styles[styleIndex]
+        List {
+            ForEach(style.sessions.indices, id: \.self) { idx in
+                NavigationLink(style.sessions[idx].name) {
+                    WorkoutView(styleIndex: styleIndex, sessionIndex: idx)
+                }
+            }
+        }
+        .navigationTitle(style.name)
+    }
+}
+
+struct SessionListView_Previews: PreviewProvider {
+    static var previews: some View {
+        SessionListView(styleIndex: 0)
+    }
+}
+

--- a/iWorkout Watch App/Workout/Views/StyleListView.swift
+++ b/iWorkout Watch App/Workout/Views/StyleListView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Lists available workout styles on Apple Watch
+struct StyleListView: View {
+    @ObservedObject var shared = SharedData.shared
+
+    var body: some View {
+        List {
+            ForEach(shared.styles.indices, id: \.self) { idx in
+                NavigationLink(shared.styles[idx].name) {
+                    SessionListView(styleIndex: idx)
+                }
+            }
+        }
+        .navigationTitle("Workouts")
+    }
+}
+
+struct StyleListView_Previews: PreviewProvider {
+    static var previews: some View {
+        StyleListView()
+    }
+}
+

--- a/iWorkout Watch App/Workout/Views/WorkoutView.swift
+++ b/iWorkout Watch App/Workout/Views/WorkoutView.swift
@@ -1,0 +1,47 @@
+//
+//  WorkoutView.swift
+//  iWorkout Watch App
+//
+//  Created by João Anelli on 6/3/25.
+//
+
+import SwiftUI
+
+/// Displays the exercises for a selected workout session
+struct WorkoutView: View {
+    @StateObject private var viewModel: WatchWorkoutViewModel
+
+    init(styleIndex: Int, sessionIndex: Int) {
+        _viewModel = StateObject(wrappedValue: WatchWorkoutViewModel(styleIndex: styleIndex,
+                                                                    sessionIndex: sessionIndex))
+    }
+    
+    var body: some View {
+        VStack {
+            if viewModel.showingRest {
+                Text("Rest: \(viewModel.restTime)s")
+                    .font(.title2)
+            } else {
+                if let session = viewModel.currentSession,
+                   session.exercises.indices.contains(viewModel.currentIndex) {
+                    Text(session.exercises[viewModel.currentIndex].name)
+                        .font(.headline)
+                        .padding()
+                    Button("Next") {
+                        viewModel.nextExercise()
+                    }
+                    .padding(.top, 10)
+                } else {
+                    Text("No exercise")
+                        .padding()
+                }
+            }
+        }
+    }
+}
+
+struct WorkoutView_Previews: PreviewProvider {
+    static var previews: some View {
+        WorkoutView(styleIndex: 0, sessionIndex: 0)
+    }
+}


### PR DESCRIPTION
## Summary
- split Apple Watch flow into three screens
- add list views for selecting style and session
- remove pickers from workout view
- localize new titles

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c963ac7083319df5498dfde9d828