### PR TITLE
Implement manual sync via shake

### DIFF
--- a/Shared/UIComponents/ShakeDetector.swift
+++ b/Shared/UIComponents/ShakeDetector.swift
@@ -1,0 +1,40 @@
+#if os(iOS)
+import SwiftUI
+
+struct ShakeDetector: UIViewRepresentable {
+    var onShake: () -> Void
+
+    func makeUIView(context: Context) -> ShakeDetectingView {
+        let view = ShakeDetectingView()
+        view.onShake = onShake
+        return view
+    }
+
+    func updateUIView(_ uiView: ShakeDetectingView, context: Context) {
+        uiView.onShake = onShake
+    }
+}
+
+class ShakeDetectingView: UIView {
+    var onShake: (() -> Void)?
+
+    override var canBecomeFirstResponder: Bool { true }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        becomeFirstResponder()
+    }
+
+    override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        guard motion == .motionShake else { return }
+        onShake?()
+    }
+}
+
+extension View {
+    /// Calls action when the user shakes the device.
+    func onShake(perform action: @escaping () -> Void) -> some View {
+        self.background(ShakeDetector(onShake: action))
+    }
+}
+#endif

--- a/iWorkout/App/iWorkoutApp.swift
+++ b/iWorkout/App/iWorkoutApp.swift
@@ -9,13 +9,24 @@ import SwiftUI
 
 @main
 struct iWorkoutApp: App {
+    @State private var showSendConfirm = false
+
     init() {
         _ = SharedData.shared
     }
-    
+
     var body: some Scene {
         WindowGroup {
             WorkoutStyleListView()
+                .onShake { showSendConfirm = true }
+                .alert(NSLocalizedString("Send to Apple Watch?", comment: ""),
+                       isPresented: $showSendConfirm) {
+                    Button(NSLocalizedString("Send", comment: "")) {
+                        SharedData.shared.sendStyles(SharedData.shared.styles)
+                    }
+                    Button(NSLocalizedString("Cancel", comment: ""),
+                           role: .cancel) { }
+                }
         }
     }
 }

--- a/iWorkout/Resources/en.lproj/Localizable.strings
+++ b/iWorkout/Resources/en.lproj/Localizable.strings
@@ -21,3 +21,5 @@
 "Edit Style" = "Edit Style";
 "Edit Session" = "Edit Session";
 "New Exercise" = "New Exercise";
+"Send to Apple Watch?" = "Send to Apple Watch?";
+"Send" = "Send";

--- a/iWorkout/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout/Resources/pt.lproj/Localizable.strings
@@ -22,3 +22,5 @@
 "Edit Style" = "Editar Estilo";
 "Edit Session" = "Editar Sessão";
 "New Exercise" = "Novo Exercício";
+"Send to Apple Watch?" = "Enviar para o Apple Watch?";
+"Send" = "Enviar";


### PR DESCRIPTION
## Summary
- add ShakeDetector component for iOS
- show alert on shake in main app to sync workouts
- localize new alert strings

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f1a35b20833196383aaeac95c183