### PR TITLE
Add empty list messages

### DIFF
--- a/iWorkout Watch App/Resources/en.lproj/Localizable.strings
+++ b/iWorkout Watch App/Resources/en.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 "My Workouts" = "My Workouts";
 "You haven't added exercises yet" = "You haven't added exercises yet";
+"You haven't added sessions yet" = "You haven't added sessions yet";
+"You haven't added workouts yet" = "You haven't added workouts yet";
 "New Ex. %d" = "New Ex. %d";
 "Delete exercise?" = "Delete exercise?";
 "Delete" = "Delete";

--- a/iWorkout Watch App/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout Watch App/Resources/pt.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 "My Workouts" = "Meus Treinos";
 "You haven't added exercises yet" = "Você ainda não adicionou exercícios";
+"You haven't added sessions yet" = "Você ainda não adicionou divisões";
+"You haven't added workouts yet" = "Você ainda não adicionou treinos";
 "New Ex. %d" = "Novo Ex. %d";
 "Delete exercise?" = "Excluir exercício?";
 "Delete" = "Excluir";

--- a/iWorkout Watch App/Workout/Views/SessionListView.swift
+++ b/iWorkout Watch App/Workout/Views/SessionListView.swift
@@ -8,9 +8,15 @@ struct SessionListView: View {
     var body: some View {
         let style = shared.styles[styleIndex]
         List {
-            ForEach(style.sessions.indices, id: \.self) { idx in
-                NavigationLink(style.sessions[idx].name) {
-                    WorkoutView(styleIndex: styleIndex, sessionIndex: idx)
+            if style.sessions.isEmpty {
+                Text("You haven't added sessions yet")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                ForEach(style.sessions.indices, id: \.self) { idx in
+                    NavigationLink(style.sessions[idx].name) {
+                        WorkoutView(styleIndex: styleIndex, sessionIndex: idx)
+                    }
                 }
             }
         }

--- a/iWorkout Watch App/Workout/Views/StyleListView.swift
+++ b/iWorkout Watch App/Workout/Views/StyleListView.swift
@@ -6,9 +6,15 @@ struct StyleListView: View {
 
     var body: some View {
         List {
-            ForEach(shared.styles.indices, id: \.self) { idx in
-                NavigationLink(shared.styles[idx].name) {
-                    SessionListView(styleIndex: idx)
+            if shared.styles.isEmpty {
+                Text("You haven't added workouts yet")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                ForEach(shared.styles.indices, id: \.self) { idx in
+                    NavigationLink(shared.styles[idx].name) {
+                        SessionListView(styleIndex: idx)
+                    }
                 }
             }
         }

--- a/iWorkout/Exercises/Views/WorkoutSessionListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutSessionListView.swift
@@ -11,17 +11,23 @@ struct WorkoutSessionListView: View {
     var body: some View {
         List {
             Section {
-                ForEach(viewModel.sessions) { session in
-                    NavigationLink(session.name) {
-                        ExerciseListView(model: ExerciseListViewModel(session: session) { updated in
-                            viewModel.updateSession(updated)
-                        })
-                    }
-                    .swipeActions {
-                        Button(role: .destructive) {
-                            viewModel.removeSession(session)
-                        } label: {
-                            Label("Delete", systemImage: "trash")
+                if viewModel.sessions.isEmpty {
+                    Text("You haven't added sessions yet")
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                } else {
+                    ForEach(viewModel.sessions) { session in
+                        NavigationLink(session.name) {
+                            ExerciseListView(model: ExerciseListViewModel(session: session) { updated in
+                                viewModel.updateSession(updated)
+                            })
+                        }
+                        .swipeActions {
+                            Button(role: .destructive) {
+                                viewModel.removeSession(session)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
                         }
                     }
                 }

--- a/iWorkout/Exercises/Views/WorkoutStyleListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutStyleListView.swift
@@ -9,15 +9,21 @@ struct WorkoutStyleListView: View {
     var body: some View {
         NavigationView {
             List {
-                ForEach(model.styles) { style in
-                    NavigationLink(style.name) {
-                        WorkoutSessionListView(viewModel: WorkoutSessionViewModel(style: style) { updated in
-                            model.updateStyle(updated)
-                        })
+                if model.styles.isEmpty {
+                    Text("You haven't added workouts yet")
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                } else {
+                    ForEach(model.styles) { style in
+                        NavigationLink(style.name) {
+                            WorkoutSessionListView(viewModel: WorkoutSessionViewModel(style: style) { updated in
+                                model.updateStyle(updated)
+                            })
+                        }
                     }
-                }
-                .onDelete { indexSet in
-                    model.styles.remove(atOffsets: indexSet)
+                    .onDelete { indexSet in
+                        model.styles.remove(atOffsets: indexSet)
+                    }
                 }
             }
             .navigationTitle("Workouts")

--- a/iWorkout/Resources/en.lproj/Localizable.strings
+++ b/iWorkout/Resources/en.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 "My Workouts" = "My Workouts";
 "You haven't added exercises yet" = "You haven't added exercises yet";
+"You haven't added sessions yet" = "You haven't added sessions yet";
+"You haven't added workouts yet" = "You haven't added workouts yet";
 "New Ex. %d" = "New Ex. %d";
 "Delete exercise?" = "Delete exercise?";
 "Delete" = "Delete";

--- a/iWorkout/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout/Resources/pt.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 "My Workouts" = "Meus Treinos";
 "You haven't added exercises yet" = "Você ainda não adicionou exercícios";
+"You haven't added sessions yet" = "Você ainda não adicionou divisões";
+"You haven't added workouts yet" = "Você ainda não adicionou treinos";
 "New Ex. %d" = "Novo Ex. %d";
 "Delete exercise?" = "Excluir exercício?";
 "Delete" = "Excluir";


### PR DESCRIPTION
## Summary
- show placeholder text when workout style list is empty
- show placeholder text when session list is empty
- mirror the same messages in watchOS views
- localize the new placeholder strings

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build`


------
https://chatgpt.com/codex/tasks/task_e_684509446d6483318cbc7145acdeac2f