### PR TITLE
Move add/edit buttons to footer in exercise view

### DIFF
--- a/iWorkout/Exercises/Views/ExerciseListView.swift
+++ b/iWorkout/Exercises/Views/ExerciseListView.swift
@@ -59,14 +59,18 @@ struct ExerciseListView: View {
                 }
             }
         }
-        .toolbar {
-            ToolbarItemGroup(placement: .navigationBarTrailing) {
-                Button { showAddExercise = true } label: { Image(systemName: "plus") }
-                Button {
+        .safeAreaInset(edge: .bottom) {
+            HStack {
+                Button("Add Exercise") { showAddExercise = true }
+                    .bold()
+                Spacer()
+                Button("Edit Session") {
                     sessionName = model.session.name
                     showEditSession = true
-                } label: { Image(systemName: "pencil") }
+                }
             }
+            .padding(.vertical, 12)
+            .padding(.horizontal, 16)
         }
         .sheet(isPresented: $showAddExercise) {
             NavigationView {

--- a/iWorkout/Resources/en.lproj/Localizable.strings
+++ b/iWorkout/Resources/en.lproj/Localizable.strings
@@ -26,4 +26,5 @@
 "Send to Apple Watch?" = "Send to Apple Watch?";
 "Send" = "Send";
 "Add Workout" = "Add Workout";
+"Add Exercise" = "Add Exercise";
 "Edit" = "Edit";

--- a/iWorkout/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout/Resources/pt.lproj/Localizable.strings
@@ -27,4 +27,5 @@
 "Send to Apple Watch?" = "Enviar para o Apple Watch?";
 "Send" = "Enviar";
 "Add Workout" = "Adicionar Treino";
+"Add Exercise" = "Adicionar Exercício";
 "Edit" = "Editar";


### PR DESCRIPTION
## Summary
- place Add Exercise and Edit Session buttons in bottom bar of ExerciseListView
- localize Add Exercise button text

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684651a051648331a84a9029fc3bf527