### PR TITLE
Move session controls to footer

### DIFF
--- a/iWorkout/Exercises/Views/WorkoutSessionListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutSessionListView.swift
@@ -45,17 +45,23 @@ struct WorkoutSessionListView: View {
             }
         }
         .navigationTitle(viewModel.style.name)
-        .toolbar {
-            ToolbarItemGroup(placement: .navigationBarTrailing) {
-                Button(action: { showAddSession = true }) {
-                    Image(systemName: "plus")
+        .safeAreaInset(edge: .bottom) {
+            HStack {
+                Button(NSLocalizedString("Add Session", comment: "")) {
+                    showAddSession = true
                 }
-                Button(action: {
+                .fontWeight(.bold)
+                .padding(.vertical, 12)
+                .padding(.horizontal, 16)
+
+                Spacer()
+
+                Button(NSLocalizedString("Edit Workout", comment: "")) {
                     editedStyleName = viewModel.style.name
                     showEditStyle = true
-                }) {
-                    Image(systemName: "pencil")
                 }
+                .padding(.vertical, 12)
+                .padding(.horizontal, 16)
             }
         }
         .sheet(isPresented: $showAddSession) {

--- a/iWorkout/Resources/en.lproj/Localizable.strings
+++ b/iWorkout/Resources/en.lproj/Localizable.strings
@@ -27,3 +27,5 @@
 "Send" = "Send";
 "Add Workout" = "Add Workout";
 "Edit" = "Edit";
+"Add Session" = "Add Session";
+"Edit Workout" = "Edit Workout";

--- a/iWorkout/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout/Resources/pt.lproj/Localizable.strings
@@ -28,3 +28,5 @@
 "Send" = "Enviar";
 "Add Workout" = "Adicionar Treino";
 "Edit" = "Editar";
+"Add Session" = "Adicionar Divisão";
+"Edit Workout" = "Editar Treino";


### PR DESCRIPTION
## Summary
- move session add/edit buttons to footer bar
- localize "Add Session" and "Edit Workout" strings

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build`


------
https://chatgpt.com/codex/tasks/task_e_6846516d05788331be00eafb61d986a1