### PR TITLE
Add active fields to WorkoutStyle

### DIFF
--- a/Shared/Entities/WorkoutStyle.swift
+++ b/Shared/Entities/WorkoutStyle.swift
@@ -4,10 +4,18 @@ struct WorkoutStyle: Identifiable, Codable, Equatable {
     var id = UUID()
     var name: String
     var sessions: [WorkoutSession]
+    var isActive: Bool
+    var activeUntil: Date?
 
-    init(id: UUID = UUID(), name: String, sessions: [WorkoutSession] = []) {
+    init(id: UUID = UUID(),
+         name: String,
+         sessions: [WorkoutSession] = [],
+         isActive: Bool = true,
+         activeUntil: Date? = nil) {
         self.id = id
         self.name = name
         self.sessions = sessions
+        self.isActive = isActive
+        self.activeUntil = activeUntil
     }
 }

--- a/iWorkout Watch App/Resources/en.lproj/Localizable.strings
+++ b/iWorkout Watch App/Resources/en.lproj/Localizable.strings
@@ -23,3 +23,5 @@
 "Sessions" = "Sessions";
 "Workouts" = "Workouts";
 "Add Workout" = "Add Workout";
+"Active" = "Active";
+"Active Until" = "Active Until";

--- a/iWorkout Watch App/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout Watch App/Resources/pt.lproj/Localizable.strings
@@ -23,3 +23,5 @@
 "Sessions" = "Divisões";
 "Workouts" = "Treinos";
 "Add Workout" = "Adicionar Treino";
+"Active" = "Ativo";
+"Active Until" = "Ativo Até";

--- a/iWorkout/Exercises/ViewModels/WorkoutStyleListViewModel.swift
+++ b/iWorkout/Exercises/ViewModels/WorkoutStyleListViewModel.swift
@@ -15,8 +15,13 @@ class WorkoutStyleListViewModel: ObservableObject {
         load()
     }
 
-    func addStyle(_ name: String) {
-        styles.append(WorkoutStyle(name: name))
+    func addStyle(_ name: String,
+                  isActive: Bool = true,
+                  activeUntil: Date? = nil) {
+        styles.append(WorkoutStyle(name: name,
+                                   sessions: [],
+                                   isActive: isActive,
+                                   activeUntil: activeUntil))
     }
 
     func updateStyle(_ style: WorkoutStyle) {

--- a/iWorkout/Exercises/Views/WorkoutSessionListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutSessionListView.swift
@@ -7,6 +7,8 @@ struct WorkoutSessionListView: View {
     @State private var newSessionName = ""
     @State private var showEditStyle = false
     @State private var editedStyleName = ""
+    @State private var editedStyleActive = true
+    @State private var editedActiveUntil = Date()
     @State private var editingSession: WorkoutSession?
     @State private var editedSessionName = ""
 
@@ -58,6 +60,8 @@ struct WorkoutSessionListView: View {
 
                 Button(NSLocalizedString("Edit Workout", comment: "")) {
                     editedStyleName = viewModel.style.name
+                    editedStyleActive = viewModel.style.isActive
+                    editedActiveUntil = viewModel.style.activeUntil ?? Date()
                     showEditStyle = true
                 }
                 .padding(.vertical, 12)
@@ -109,9 +113,9 @@ struct WorkoutSessionListView: View {
         }
         .sheet(isPresented: $showEditStyle) {
             NavigationView {
-                Form {
-                    TextField("Style name", text: $editedStyleName)
-                }
+                WorkoutStyleForm(name: $editedStyleName,
+                                 isActive: $editedStyleActive,
+                                 activeUntil: $editedActiveUntil)
                 .navigationTitle("Edit Style")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
@@ -120,6 +124,8 @@ struct WorkoutSessionListView: View {
                     ToolbarItem(placement: .confirmationAction) {
                         Button("Save") {
                             viewModel.style.name = editedStyleName
+                            viewModel.style.isActive = editedStyleActive
+                            viewModel.style.activeUntil = editedStyleActive ? editedActiveUntil : nil
                             showEditStyle = false
                         }
                         .disabled(editedStyleName.isEmpty)

--- a/iWorkout/Exercises/Views/WorkoutStyleForm.swift
+++ b/iWorkout/Exercises/Views/WorkoutStyleForm.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct WorkoutStyleForm: View {
+    @Binding var name: String
+    @Binding var isActive: Bool
+    @Binding var activeUntil: Date
+
+    var body: some View {
+        Form {
+            TextField("Style name", text: $name)
+            Toggle("Active", isOn: $isActive)
+            if isActive {
+                DatePicker("Active Until", selection: $activeUntil, displayedComponents: .date)
+            }
+        }
+    }
+}
+
+struct WorkoutStyleForm_Previews: PreviewProvider {
+    @State static private var name = "Sample"
+    @State static private var isActive = true
+    @State static private var date = Date()
+
+    static var previews: some View {
+        WorkoutStyleForm(name: $name, isActive: $isActive, activeUntil: $date)
+    }
+}

--- a/iWorkout/Exercises/Views/WorkoutStyleListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutStyleListView.swift
@@ -5,8 +5,12 @@ struct WorkoutStyleListView: View {
     @StateObject private var model = WorkoutStyleListViewModel()
     @State private var showAddStyle = false
     @State private var newStyleName = ""
+    @State private var newStyleActive = true
+    @State private var newActiveUntil = Date()
     @State private var editingStyle: WorkoutStyle?
     @State private var editedStyleName = ""
+    @State private var editedStyleActive = true
+    @State private var editedActiveUntil = Date()
 
     var body: some View {
         NavigationView {
@@ -34,6 +38,8 @@ struct WorkoutStyleListView: View {
                             Button {
                                 editingStyle = style
                                 editedStyleName = style.name
+                                editedStyleActive = style.isActive
+                                editedActiveUntil = style.activeUntil ?? Date()
                             } label: {
                                 Label("Edit", systemImage: "pencil")
                             }
@@ -53,9 +59,9 @@ struct WorkoutStyleListView: View {
             }
             .sheet(isPresented: $showAddStyle) {
                 NavigationView {
-                    Form {
-                        TextField("Style name", text: $newStyleName)
-                    }
+                    WorkoutStyleForm(name: $newStyleName,
+                                     isActive: $newStyleActive,
+                                     activeUntil: $newActiveUntil)
                     .navigationTitle("New Style")
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
@@ -63,9 +69,13 @@ struct WorkoutStyleListView: View {
                         }
                         ToolbarItem(placement: .confirmationAction) {
                             Button("Add") {
-                                model.addStyle(newStyleName)
+                                model.addStyle(newStyleName,
+                                               isActive: newStyleActive,
+                                               activeUntil: newStyleActive ? newActiveUntil : nil)
                                 showAddStyle = false
                                 newStyleName = ""
+                                newStyleActive = true
+                                newActiveUntil = Date()
                             }
                             .disabled(newStyleName.isEmpty)
                         }
@@ -74,7 +84,9 @@ struct WorkoutStyleListView: View {
             }
             .sheet(item: $editingStyle) { style in
                 NavigationView {
-                    Form { TextField("Style name", text: $editedStyleName) }
+                    WorkoutStyleForm(name: $editedStyleName,
+                                     isActive: $editedStyleActive,
+                                     activeUntil: $editedActiveUntil)
                     .navigationTitle("Edit Style")
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
@@ -84,6 +96,8 @@ struct WorkoutStyleListView: View {
                             Button("Save") {
                                 if let idx = model.styles.firstIndex(of: style) {
                                     model.styles[idx].name = editedStyleName
+                                    model.styles[idx].isActive = editedStyleActive
+                                    model.styles[idx].activeUntil = editedStyleActive ? editedActiveUntil : nil
                                 }
                                 editingStyle = nil
                             }

--- a/iWorkout/Resources/en.lproj/Localizable.strings
+++ b/iWorkout/Resources/en.lproj/Localizable.strings
@@ -31,3 +31,5 @@
 "Add Session" = "Add Session";
 "Edit Workout" = "Edit Workout";
 "New Session" = "New Session";
+"Active" = "Active";
+"Active Until" = "Active Until";

--- a/iWorkout/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout/Resources/pt.lproj/Localizable.strings
@@ -32,3 +32,5 @@
 "Add Session" = "Adicionar Divisão";
 "Edit Workout" = "Editar Treino";
 "New Session" = "Nova Divisão";
+"Active" = "Ativo";
+"Active Until" = "Ativo Até";


### PR DESCRIPTION
## Summary
- add `isActive` and `activeUntil` to `WorkoutStyle`
- create `WorkoutStyleForm` for editing style data
- enable editing of active fields in style forms
- localize new UI strings

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684725340444833184e64f4a9258c992