### PR TITLE
Add repetitions and weekday fields

### DIFF
--- a/Shared/Entities/WorkoutSession.swift
+++ b/Shared/Entities/WorkoutSession.swift
@@ -1,13 +1,27 @@
 import Foundation
 
+enum Weekday: String, CaseIterable, Codable, Identifiable {
+    case monday, tuesday, wednesday, thursday, friday, saturday, sunday
+
+    var id: String { rawValue }
+}
+
 struct WorkoutSession: Identifiable, Codable, Equatable {
     var id = UUID()
     var name: String
+    var repetitions: Int
+    var weekday: Weekday?
     var exercises: [Exercise]
 
-    init(id: UUID = UUID(), name: String, exercises: [Exercise] = []) {
+    init(id: UUID = UUID(),
+         name: String,
+         repetitions: Int = 1,
+         weekday: Weekday? = nil,
+         exercises: [Exercise] = []) {
         self.id = id
         self.name = name
+        self.repetitions = repetitions
+        self.weekday = weekday
         self.exercises = exercises
     }
 }

--- a/Shared/Entities/WorkoutStyle.swift
+++ b/Shared/Entities/WorkoutStyle.swift
@@ -1,13 +1,22 @@
 import Foundation
 
+enum SessionBy: String, CaseIterable, Codable {
+    case sequence, weekday
+}
+
 struct WorkoutStyle: Identifiable, Codable, Equatable {
     var id = UUID()
     var name: String
+    var sessionBy: SessionBy
     var sessions: [WorkoutSession]
 
-    init(id: UUID = UUID(), name: String, sessions: [WorkoutSession] = []) {
+    init(id: UUID = UUID(),
+         name: String,
+         sessionBy: SessionBy = .sequence,
+         sessions: [WorkoutSession] = []) {
         self.id = id
         self.name = name
+        self.sessionBy = sessionBy
         self.sessions = sessions
     }
 }

--- a/iWorkout/Exercises/ViewModels/WorkoutSessionViewModel.swift
+++ b/iWorkout/Exercises/ViewModels/WorkoutSessionViewModel.swift
@@ -17,8 +17,10 @@ class WorkoutSessionViewModel: ObservableObject {
         set { style.sessions = newValue }
     }
 
-    func addSession(_ name: String) {
-        style.sessions.append(WorkoutSession(name: name))
+    func addSession(_ name: String, repetitions: Int, weekday: Weekday?) {
+        style.sessions.append(
+            WorkoutSession(name: name, repetitions: repetitions, weekday: weekday)
+        )
     }
 
     func updateSession(_ session: WorkoutSession) {

--- a/iWorkout/Exercises/Views/WorkoutSessionListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutSessionListView.swift
@@ -5,10 +5,14 @@ struct WorkoutSessionListView: View {
     @StateObject var viewModel: WorkoutSessionViewModel
     @State private var showAddSession = false
     @State private var newSessionName = ""
+    @State private var newRepetitions: Int = 1
+    @State private var newWeekday: Weekday = .monday
     @State private var showEditStyle = false
     @State private var editedStyleName = ""
     @State private var editingSession: WorkoutSession?
     @State private var editedSessionName = ""
+    @State private var editedRepetitions: Int = 1
+    @State private var editedWeekday: Weekday = .monday
 
     var body: some View {
         List {
@@ -34,6 +38,8 @@ struct WorkoutSessionListView: View {
                             Button {
                                 editingSession = session
                                 editedSessionName = session.name
+                                editedRepetitions = session.repetitions
+                                editedWeekday = session.weekday ?? .monday
                             } label: {
                                 Label("Edit", systemImage: "pencil")
                             }
@@ -68,6 +74,16 @@ struct WorkoutSessionListView: View {
             NavigationView {
                 Form {
                     TextField("Session name", text: $newSessionName)
+                    Stepper(value: $newRepetitions, in: 1...50) {
+                        Text("\(newRepetitions) " + NSLocalizedString("Repetitions", comment: ""))
+                    }
+                    if viewModel.style.sessionBy == .weekday {
+                        Picker("Weekday", selection: $newWeekday) {
+                            ForEach(Weekday.allCases) { day in
+                                Text(NSLocalizedString(day.rawValue.capitalized, comment: "")).tag(day)
+                            }
+                        }
+                    }
                 }
                 .navigationTitle("New Session")
                 .toolbar {
@@ -76,9 +92,11 @@ struct WorkoutSessionListView: View {
                     }
                     ToolbarItem(placement: .confirmationAction) {
                         Button("Add") {
-                            viewModel.addSession(newSessionName)
+                            let weekday = viewModel.style.sessionBy == .weekday ? newWeekday : nil
+                            viewModel.addSession(newSessionName, repetitions: newRepetitions, weekday: weekday)
                             showAddSession = false
                             newSessionName = ""
+                            newRepetitions = 1
                         }
                         .disabled(newSessionName.isEmpty)
                     }
@@ -89,6 +107,16 @@ struct WorkoutSessionListView: View {
             NavigationView {
                 Form {
                     TextField("Session name", text: $editedSessionName)
+                    Stepper(value: $editedRepetitions, in: 1...50) {
+                        Text("\(editedRepetitions) " + NSLocalizedString("Repetitions", comment: ""))
+                    }
+                    if viewModel.style.sessionBy == .weekday {
+                        Picker("Weekday", selection: $editedWeekday) {
+                            ForEach(Weekday.allCases) { day in
+                                Text(NSLocalizedString(day.rawValue.capitalized, comment: "")).tag(day)
+                            }
+                        }
+                    }
                 }
                 .navigationTitle("Edit Session")
                 .toolbar {
@@ -99,6 +127,8 @@ struct WorkoutSessionListView: View {
                         Button("Save") {
                             var updated = session
                             updated.name = editedSessionName
+                            updated.repetitions = editedRepetitions
+                            updated.weekday = viewModel.style.sessionBy == .weekday ? editedWeekday : nil
                             viewModel.updateSession(updated)
                             editingSession = nil
                         }

--- a/iWorkout/Resources/en.lproj/Localizable.strings
+++ b/iWorkout/Resources/en.lproj/Localizable.strings
@@ -31,3 +31,12 @@
 "Add Session" = "Add Session";
 "Edit Workout" = "Edit Workout";
 "New Session" = "New Session";
+"Repetitions" = "Repetitions";
+"Weekday" = "Weekday";
+"Monday" = "Monday";
+"Tuesday" = "Tuesday";
+"Wednesday" = "Wednesday";
+"Thursday" = "Thursday";
+"Friday" = "Friday";
+"Saturday" = "Saturday";
+"Sunday" = "Sunday";

--- a/iWorkout/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout/Resources/pt.lproj/Localizable.strings
@@ -32,3 +32,12 @@
 "Add Session" = "Adicionar Divisão";
 "Edit Workout" = "Editar Treino";
 "New Session" = "Nova Divisão";
+"Repetitions" = "Repetições";
+"Weekday" = "Dia da semana";
+"Monday" = "Segunda-feira";
+"Tuesday" = "Terça-feira";
+"Wednesday" = "Quarta-feira";
+"Thursday" = "Quinta-feira";
+"Friday" = "Sexta-feira";
+"Saturday" = "Sábado";
+"Sunday" = "Domingo";


### PR DESCRIPTION
## Summary
- support repetitions and weekday on `WorkoutSession`
- show new inputs in workout session forms
- localize weekday strings

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684726a003908331ab2f48c71eb848d4