### PR TITLE
Replace safe area inset bars with toolbar

### DIFF
--- a/iWorkout/Exercises/Views/ExerciseListView.swift
+++ b/iWorkout/Exercises/Views/ExerciseListView.swift
@@ -59,8 +59,8 @@ struct ExerciseListView: View {
                 }
             }
         }
-        .safeAreaInset(edge: .bottom) {
-            HStack {
+        .toolbar {
+            ToolbarItemGroup(placement: .bottomBar) {
                 Button("Add Exercise") { showAddExercise = true }
                     .bold()
                 Spacer()
@@ -69,9 +69,6 @@ struct ExerciseListView: View {
                     showEditSession = true
                 }
             }
-            .padding(.vertical, 16)
-            .padding(.horizontal, 16)
-            .background(.thinMaterial)
         }
         .sheet(isPresented: $showAddExercise) {
             NavigationView {

--- a/iWorkout/Exercises/Views/WorkoutSessionListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutSessionListView.swift
@@ -45,14 +45,12 @@ struct WorkoutSessionListView: View {
             }
         }
         .navigationTitle(viewModel.style.name)
-        .safeAreaInset(edge: .bottom) {
-            HStack {
+        .toolbar {
+            ToolbarItemGroup(placement: .bottomBar) {
                 Button(NSLocalizedString("Add Session", comment: "")) {
                     showAddSession = true
                 }
                 .fontWeight(.bold)
-                .padding(.vertical, 12)
-                .padding(.horizontal, 16)
 
                 Spacer()
 
@@ -60,8 +58,6 @@ struct WorkoutSessionListView: View {
                     editedStyleName = viewModel.style.name
                     showEditStyle = true
                 }
-                .padding(.vertical, 12)
-                .padding(.horizontal, 16)
             }
         }
         .sheet(isPresented: $showAddSession) {

--- a/iWorkout/Exercises/Views/WorkoutStyleListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutStyleListView.swift
@@ -43,13 +43,11 @@ struct WorkoutStyleListView: View {
                 }
             }
             .navigationTitle("Workouts")
-            .safeAreaInset(edge: .bottom) {
-                HStack {
+            .toolbar {
+                ToolbarItemGroup(placement: .bottomBar) {
                     Spacer()
                     Button("Add Workout") { showAddStyle = true }
-                        .padding(.vertical, 16)
-                        .padding(.horizontal, 16)
-                }.background(.thinMaterial)
+                }
             }
             .sheet(isPresented: $showAddStyle) {
                 NavigationView {


### PR DESCRIPTION
## Summary
- move bottom buttons into a toolbar on ExerciseListView
- move bottom buttons into a toolbar on WorkoutStyleListView
- move bottom buttons into a toolbar on WorkoutSessionListView
- remove thin material backgrounds from bottom toolbars

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a361f0c9883318eddd736515ad97d