### PR TITLE
Switch buttons to icon-based design

### DIFF
--- a/iWorkout Watch App/Workout/Views/WorkoutView.swift
+++ b/iWorkout Watch App/Workout/Views/WorkoutView.swift
@@ -27,9 +27,12 @@ struct WorkoutView: View {
                     Text(session.exercises[viewModel.currentIndex].name)
                         .font(.headline)
                         .padding()
-                    Button("Next") {
+                    Button {
                         viewModel.nextExercise()
+                    } label: {
+                        Image(systemName: "arrow.right")
                     }
+                    .buttonStyle(.borderedProminent)
                     .padding(.top, 10)
                 } else {
                     Text("No exercise")

--- a/iWorkout/App/iWorkoutApp.swift
+++ b/iWorkout/App/iWorkoutApp.swift
@@ -21,11 +21,16 @@ struct iWorkoutApp: App {
                 .onShake { showSendConfirm = true }
                 .alert(NSLocalizedString("Send to Apple Watch?", comment: ""),
                        isPresented: $showSendConfirm) {
-                    Button(NSLocalizedString("Send", comment: "")) {
+                    Button {
                         SharedData.shared.sendStyles(SharedData.shared.styles)
+                    } label: {
+                        Image(systemName: "paperplane.fill")
                     }
-                    Button(NSLocalizedString("Cancel", comment: ""),
-                           role: .cancel) { }
+                    .buttonStyle(.borderedProminent)
+                    Button(role: .cancel) {
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
                 }
         }
     }

--- a/iWorkout/Exercises/Views/ExerciseListView.swift
+++ b/iWorkout/Exercises/Views/ExerciseListView.swift
@@ -61,13 +61,17 @@ struct ExerciseListView: View {
         }
         .safeAreaInset(edge: .bottom) {
             HStack {
-                Button("Add Exercise") { showAddExercise = true }
-                    .bold()
-                Spacer()
-                Button("Edit Session") {
+                Button {
                     sessionName = model.session.name
                     showEditSession = true
+                } label: {
+                    Image(systemName: "pencil")
                 }
+                Spacer()
+                Button { showAddExercise = true } label: {
+                    Image(systemName: "plus")
+                }
+                .bold()
             }
             .padding(.vertical, 16)
             .padding(.horizontal, 16)
@@ -92,16 +96,21 @@ struct ExerciseListView: View {
                 .navigationTitle("New Exercise")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { showAddExercise = false }
+                        Button { showAddExercise = false } label: {
+                            Image(systemName: "xmark")
+                        }
                     }
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Add") {
+                        Button {
                             model.addExercise(name: newExerciseName, sets: newExerciseSets, restDuration: newExerciseRest)
                             showAddExercise = false
                             newExerciseName = ""
                             newExerciseSets = 3
                             newExerciseRest = 60
+                        } label: {
+                            Image(systemName: "plus")
                         }
+                        .buttonStyle(.borderedProminent)
                         .disabled(newExerciseName.isEmpty)
                     }
                 }
@@ -115,13 +124,18 @@ struct ExerciseListView: View {
                 .navigationTitle("Edit Session")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { showEditSession = false }
+                        Button { showEditSession = false } label: {
+                            Image(systemName: "xmark")
+                        }
                     }
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Save") {
+                        Button {
                             model.session.name = sessionName
                             showEditSession = false
+                        } label: {
+                            Image(systemName: "checkmark")
                         }
+                        .buttonStyle(.borderedProminent)
                         .disabled(sessionName.isEmpty)
                     }
                 }
@@ -137,11 +151,15 @@ struct ExerciseListView: View {
             }
         }
         .alert("Delete exercise?", isPresented: $showDeleteConfirm, presenting: exerciseToDelete) { exercise in
-            Button("Delete", role: .destructive) {
+            Button(role: .destructive) {
                 model.removeExercise(exercise)
+            } label: {
+                Image(systemName: "trash")
             }
             .tint(Color("AlertCoral"))
-            Button("Cancel", role: .cancel) { }
+            Button(role: .cancel) { } label: {
+                Image(systemName: "xmark")
+            }
         }
     }
 }

--- a/iWorkout/Exercises/Views/WorkoutSessionListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutSessionListView.swift
@@ -47,19 +47,23 @@ struct WorkoutSessionListView: View {
         .navigationTitle(viewModel.style.name)
         .safeAreaInset(edge: .bottom) {
             HStack {
-                Button(NSLocalizedString("Add Session", comment: "")) {
-                    showAddSession = true
+                Button {
+                    editedStyleName = viewModel.style.name
+                    showEditStyle = true
+                } label: {
+                    Image(systemName: "pencil")
                 }
-                .fontWeight(.bold)
                 .padding(.vertical, 12)
                 .padding(.horizontal, 16)
 
                 Spacer()
 
-                Button(NSLocalizedString("Edit Workout", comment: "")) {
-                    editedStyleName = viewModel.style.name
-                    showEditStyle = true
+                Button {
+                    showAddSession = true
+                } label: {
+                    Image(systemName: "plus")
                 }
+                .fontWeight(.bold)
                 .padding(.vertical, 12)
                 .padding(.horizontal, 16)
             }
@@ -72,14 +76,19 @@ struct WorkoutSessionListView: View {
                 .navigationTitle("New Session")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { showAddSession = false }
+                        Button { showAddSession = false } label: {
+                            Image(systemName: "xmark")
+                        }
                     }
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Add") {
+                        Button {
                             viewModel.addSession(newSessionName)
                             showAddSession = false
                             newSessionName = ""
+                        } label: {
+                            Image(systemName: "plus")
                         }
+                        .buttonStyle(.borderedProminent)
                         .disabled(newSessionName.isEmpty)
                     }
                 }
@@ -93,15 +102,20 @@ struct WorkoutSessionListView: View {
                 .navigationTitle("Edit Session")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { editingSession = nil }
+                        Button { editingSession = nil } label: {
+                            Image(systemName: "xmark")
+                        }
                     }
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Save") {
+                        Button {
                             var updated = session
                             updated.name = editedSessionName
                             viewModel.updateSession(updated)
                             editingSession = nil
+                        } label: {
+                            Image(systemName: "checkmark")
                         }
+                        .buttonStyle(.borderedProminent)
                         .disabled(editedSessionName.isEmpty)
                     }
                 }
@@ -115,13 +129,18 @@ struct WorkoutSessionListView: View {
                 .navigationTitle("Edit Style")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { showEditStyle = false }
+                        Button { showEditStyle = false } label: {
+                            Image(systemName: "xmark")
+                        }
                     }
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Save") {
+                        Button {
                             viewModel.style.name = editedStyleName
                             showEditStyle = false
+                        } label: {
+                            Image(systemName: "checkmark")
                         }
+                        .buttonStyle(.borderedProminent)
                         .disabled(editedStyleName.isEmpty)
                     }
                 }

--- a/iWorkout/Exercises/Views/WorkoutStyleListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutStyleListView.swift
@@ -46,7 +46,9 @@ struct WorkoutStyleListView: View {
             .safeAreaInset(edge: .bottom) {
                 HStack {
                     Spacer()
-                    Button("Add Workout") { showAddStyle = true }
+                    Button { showAddStyle = true } label: {
+                        Image(systemName: "plus")
+                    }
                         .padding(.vertical, 16)
                         .padding(.horizontal, 16)
                 }.background(.thinMaterial)
@@ -59,14 +61,19 @@ struct WorkoutStyleListView: View {
                     .navigationTitle("New Style")
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
-                            Button("Cancel") { showAddStyle = false }
+                            Button { showAddStyle = false } label: {
+                                Image(systemName: "xmark")
+                            }
                         }
                         ToolbarItem(placement: .confirmationAction) {
-                            Button("Add") {
+                            Button {
                                 model.addStyle(newStyleName)
                                 showAddStyle = false
                                 newStyleName = ""
+                            } label: {
+                                Image(systemName: "plus")
                             }
+                            .buttonStyle(.borderedProminent)
                             .disabled(newStyleName.isEmpty)
                         }
                     }
@@ -78,15 +85,20 @@ struct WorkoutStyleListView: View {
                     .navigationTitle("Edit Style")
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
-                            Button("Cancel") { editingStyle = nil }
+                            Button { editingStyle = nil } label: {
+                                Image(systemName: "xmark")
+                            }
                         }
                         ToolbarItem(placement: .confirmationAction) {
-                            Button("Save") {
+                            Button {
                                 if let idx = model.styles.firstIndex(of: style) {
                                     model.styles[idx].name = editedStyleName
                                 }
                                 editingStyle = nil
+                            } label: {
+                                Image(systemName: "checkmark")
                             }
+                            .buttonStyle(.borderedProminent)
                             .disabled(editedStyleName.isEmpty)
                         }
                     }


### PR DESCRIPTION
## Summary
- swap text buttons for icons across the app
- highlight confirm actions with `.borderedProminent`
- move Edit buttons left of Add buttons

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build`


------
https://chatgpt.com/codex/tasks/task_e_684a3aca67408331b03f826874593852