### PR TITLE
Switch to icon buttons

### DIFF
--- a/iWorkout Watch App/Workout/Views/WorkoutView.swift
+++ b/iWorkout Watch App/Workout/Views/WorkoutView.swift
@@ -27,8 +27,10 @@ struct WorkoutView: View {
                     Text(session.exercises[viewModel.currentIndex].name)
                         .font(.headline)
                         .padding()
-                    Button("Next") {
+                    Button {
                         viewModel.nextExercise()
+                    } label: {
+                        Label("Next", systemImage: "chevron.right")
                     }
                     .padding(.top, 10)
                 } else {

--- a/iWorkout/App/iWorkoutApp.swift
+++ b/iWorkout/App/iWorkoutApp.swift
@@ -21,11 +21,15 @@ struct iWorkoutApp: App {
                 .onShake { showSendConfirm = true }
                 .alert(NSLocalizedString("Send to Apple Watch?", comment: ""),
                        isPresented: $showSendConfirm) {
-                    Button(NSLocalizedString("Send", comment: "")) {
+                    Button {
                         SharedData.shared.sendStyles(SharedData.shared.styles)
+                    } label: {
+                        Label(NSLocalizedString("Send", comment: ""), systemImage: "paperplane")
                     }
-                    Button(NSLocalizedString("Cancel", comment: ""),
-                           role: .cancel) { }
+                    .buttonStyle(.borderedProminent)
+                    Button(role: .cancel) { } label: {
+                        Label(NSLocalizedString("Cancel", comment: ""), systemImage: "xmark")
+                    }
                 }
         }
     }

--- a/iWorkout/Exercises/Views/ExerciseListView.swift
+++ b/iWorkout/Exercises/Views/ExerciseListView.swift
@@ -61,13 +61,17 @@ struct ExerciseListView: View {
         }
         .toolbar {
             ToolbarItemGroup(placement: .bottomBar) {
-                Button("Add Exercise") { showAddExercise = true }
-                    .bold()
-                Spacer()
-                Button("Edit Session") {
+                Button {
                     sessionName = model.session.name
                     showEditSession = true
+                } label: {
+                    Label("Edit Session", systemImage: "pencil")
                 }
+                Spacer()
+                Button { showAddExercise = true } label: {
+                    Label("Add Exercise", systemImage: "plus")
+                }
+                .bold()
             }
         }
         .sheet(isPresented: $showAddExercise) {
@@ -89,17 +93,22 @@ struct ExerciseListView: View {
                 .navigationTitle("New Exercise")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { showAddExercise = false }
+                        Button { showAddExercise = false } label: {
+                            Label("Cancel", systemImage: "xmark")
+                        }
                     }
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Add") {
+                        Button {
                             model.addExercise(name: newExerciseName, sets: newExerciseSets, restDuration: newExerciseRest)
                             showAddExercise = false
                             newExerciseName = ""
                             newExerciseSets = 3
                             newExerciseRest = 60
+                        } label: {
+                            Label("Add", systemImage: "plus")
                         }
                         .disabled(newExerciseName.isEmpty)
+                        .buttonStyle(.borderedProminent)
                     }
                 }
             }
@@ -112,14 +121,19 @@ struct ExerciseListView: View {
                 .navigationTitle("Edit Session")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { showEditSession = false }
+                        Button { showEditSession = false } label: {
+                            Label("Cancel", systemImage: "xmark")
+                        }
                     }
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Save") {
+                        Button {
                             model.session.name = sessionName
                             showEditSession = false
+                        } label: {
+                            Label("Save", systemImage: "checkmark")
                         }
                         .disabled(sessionName.isEmpty)
+                        .buttonStyle(.borderedProminent)
                     }
                 }
             }
@@ -134,11 +148,15 @@ struct ExerciseListView: View {
             }
         }
         .alert("Delete exercise?", isPresented: $showDeleteConfirm, presenting: exerciseToDelete) { exercise in
-            Button("Delete", role: .destructive) {
+            Button(role: .destructive) {
                 model.removeExercise(exercise)
+            } label: {
+                Label("Delete", systemImage: "trash")
             }
             .tint(Color("AlertCoral"))
-            Button("Cancel", role: .cancel) { }
+            Button(role: .cancel) { } label: {
+                Label("Cancel", systemImage: "xmark")
+            }
         }
     }
 }

--- a/iWorkout/Exercises/Views/WorkoutSessionListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutSessionListView.swift
@@ -47,17 +47,21 @@ struct WorkoutSessionListView: View {
         .navigationTitle(viewModel.style.name)
         .toolbar {
             ToolbarItemGroup(placement: .bottomBar) {
-                Button(NSLocalizedString("Add Session", comment: "")) {
-                    showAddSession = true
+                Button {
+                    editedStyleName = viewModel.style.name
+                    showEditStyle = true
+                } label: {
+                    Label(NSLocalizedString("Edit Workout", comment: ""), systemImage: "pencil")
                 }
-                .fontWeight(.bold)
 
                 Spacer()
 
-                Button(NSLocalizedString("Edit Workout", comment: "")) {
-                    editedStyleName = viewModel.style.name
-                    showEditStyle = true
+                Button {
+                    showAddSession = true
+                } label: {
+                    Label(NSLocalizedString("Add Session", comment: ""), systemImage: "plus")
                 }
+                .fontWeight(.bold)
             }
         }
         .sheet(isPresented: $showAddSession) {
@@ -68,15 +72,20 @@ struct WorkoutSessionListView: View {
                 .navigationTitle("New Session")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { showAddSession = false }
+                        Button { showAddSession = false } label: {
+                            Label("Cancel", systemImage: "xmark")
+                        }
                     }
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Add") {
+                        Button {
                             viewModel.addSession(newSessionName)
                             showAddSession = false
                             newSessionName = ""
+                        } label: {
+                            Label("Add", systemImage: "plus")
                         }
                         .disabled(newSessionName.isEmpty)
+                        .buttonStyle(.borderedProminent)
                     }
                 }
             }
@@ -89,16 +98,21 @@ struct WorkoutSessionListView: View {
                 .navigationTitle("Edit Session")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { editingSession = nil }
+                        Button { editingSession = nil } label: {
+                            Label("Cancel", systemImage: "xmark")
+                        }
                     }
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Save") {
+                        Button {
                             var updated = session
                             updated.name = editedSessionName
                             viewModel.updateSession(updated)
                             editingSession = nil
+                        } label: {
+                            Label("Save", systemImage: "checkmark")
                         }
                         .disabled(editedSessionName.isEmpty)
+                        .buttonStyle(.borderedProminent)
                     }
                 }
             }
@@ -111,14 +125,19 @@ struct WorkoutSessionListView: View {
                 .navigationTitle("Edit Style")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { showEditStyle = false }
+                        Button { showEditStyle = false } label: {
+                            Label("Cancel", systemImage: "xmark")
+                        }
                     }
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Save") {
+                        Button {
                             viewModel.style.name = editedStyleName
                             showEditStyle = false
+                        } label: {
+                            Label("Save", systemImage: "checkmark")
                         }
                         .disabled(editedStyleName.isEmpty)
+                        .buttonStyle(.borderedProminent)
                     }
                 }
             }

--- a/iWorkout/Exercises/Views/WorkoutStyleListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutStyleListView.swift
@@ -46,7 +46,9 @@ struct WorkoutStyleListView: View {
             .toolbar {
                 ToolbarItemGroup(placement: .bottomBar) {
                     Spacer()
-                    Button("Add Workout") { showAddStyle = true }
+                    Button { showAddStyle = true } label: {
+                        Label("Add Workout", systemImage: "plus")
+                    }
                 }
             }
             .sheet(isPresented: $showAddStyle) {
@@ -57,15 +59,20 @@ struct WorkoutStyleListView: View {
                     .navigationTitle("New Style")
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
-                            Button("Cancel") { showAddStyle = false }
+                            Button { showAddStyle = false } label: {
+                                Label("Cancel", systemImage: "xmark")
+                            }
                         }
                         ToolbarItem(placement: .confirmationAction) {
-                            Button("Add") {
+                            Button {
                                 model.addStyle(newStyleName)
                                 showAddStyle = false
                                 newStyleName = ""
+                            } label: {
+                                Label("Add", systemImage: "plus")
                             }
                             .disabled(newStyleName.isEmpty)
+                            .buttonStyle(.borderedProminent)
                         }
                     }
                 }
@@ -76,16 +83,21 @@ struct WorkoutStyleListView: View {
                     .navigationTitle("Edit Style")
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
-                            Button("Cancel") { editingStyle = nil }
+                            Button { editingStyle = nil } label: {
+                                Label("Cancel", systemImage: "xmark")
+                            }
                         }
                         ToolbarItem(placement: .confirmationAction) {
-                            Button("Save") {
+                            Button {
                                 if let idx = model.styles.firstIndex(of: style) {
                                     model.styles[idx].name = editedStyleName
                                 }
                                 editingStyle = nil
+                            } label: {
+                                Label("Save", systemImage: "checkmark")
                             }
                             .disabled(editedStyleName.isEmpty)
+                            .buttonStyle(.borderedProminent)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- replace text buttons with SF Symbol variants
- reorder edit and add actions
- mark confirming buttons as prominent

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad3cddab0833189ec30f968cbf202