### PR TITLE
Add division transitions to workouts

### DIFF
--- a/Shared/Entities/DivisionTransition.swift
+++ b/Shared/Entities/DivisionTransition.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum DivisionTransition: String, Codable, CaseIterable, Identifiable {
+    case weekly
+    case sequential
+
+    var id: Self { self }
+
+    var localized: String {
+        switch self {
+        case .weekly:
+            return NSLocalizedString("Weekly", comment: "")
+        case .sequential:
+            return NSLocalizedString("Sequential", comment: "")
+        }
+    }
+}

--- a/Shared/Entities/WorkoutSession.swift
+++ b/Shared/Entities/WorkoutSession.swift
@@ -4,10 +4,50 @@ struct WorkoutSession: Identifiable, Codable, Equatable {
     var id = UUID()
     var name: String
     var exercises: [Exercise]
+    /// Day of week for weekly transitions
+    var weekday: Weekday?
 
-    init(id: UUID = UUID(), name: String, exercises: [Exercise] = []) {
+    init(id: UUID = UUID(), name: String, exercises: [Exercise] = [], weekday: Weekday? = nil) {
         self.id = id
         self.name = name
         self.exercises = exercises
+        self.weekday = weekday
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, exercises, weekday
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        name = try container.decode(String.self, forKey: .name)
+        exercises = try container.decodeIfPresent([Exercise].self, forKey: .exercises) ?? []
+        weekday = try container.decodeIfPresent(Weekday.self, forKey: .weekday)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(exercises, forKey: .exercises)
+        try container.encodeIfPresent(weekday, forKey: .weekday)
+    }
+}
+
+enum Weekday: String, CaseIterable, Codable, Identifiable {
+    case monday, tuesday, wednesday, thursday, friday, saturday, sunday
+    var id: Self { self }
+
+    var localized: String {
+        switch self {
+        case .monday: return NSLocalizedString("Monday", comment: "")
+        case .tuesday: return NSLocalizedString("Tuesday", comment: "")
+        case .wednesday: return NSLocalizedString("Wednesday", comment: "")
+        case .thursday: return NSLocalizedString("Thursday", comment: "")
+        case .friday: return NSLocalizedString("Friday", comment: "")
+        case .saturday: return NSLocalizedString("Saturday", comment: "")
+        case .sunday: return NSLocalizedString("Sunday", comment: "")
+        }
     }
 }

--- a/Shared/Entities/WorkoutStyle.swift
+++ b/Shared/Entities/WorkoutStyle.swift
@@ -4,6 +4,8 @@ struct WorkoutStyle: Identifiable, Codable, Equatable {
     var id = UUID()
     var name: String
     var sessions: [WorkoutSession]
+    /// Defines how the style's sessions advance
+    var transition: DivisionTransition
     /// Indicates if the style is currently active
     var isActive: Bool
     /// Time when the style should automatically deactivate
@@ -12,17 +14,21 @@ struct WorkoutStyle: Identifiable, Codable, Equatable {
     init(id: UUID = UUID(),
          name: String,
          sessions: [WorkoutSession] = [],
+         transition: DivisionTransition = .sequential,
          isActive: Bool = false,
-         activeUntil: Date? = nil) {
+         activeUntil: Date? = nil,
+         currentIndex: Int = 0) {
         self.id = id
         self.name = name
         self.sessions = sessions
+        self.transition = transition
         self.isActive = isActive
         self.activeUntil = activeUntil
+        self.currentIndex = currentIndex
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, sessions, isActive, activeUntil
+        case id, name, sessions, transition, isActive, activeUntil, currentIndex
     }
 
     init(from decoder: Decoder) throws {
@@ -30,7 +36,12 @@ struct WorkoutStyle: Identifiable, Codable, Equatable {
         id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
         name = try container.decode(String.self, forKey: .name)
         sessions = try container.decodeIfPresent([WorkoutSession].self, forKey: .sessions) ?? []
+        transition = try container.decodeIfPresent(DivisionTransition.self, forKey: .transition) ?? .sequential
         isActive = try container.decodeIfPresent(Bool.self, forKey: .isActive) ?? false
         activeUntil = try container.decodeIfPresent(Date.self, forKey: .activeUntil)
+        currentIndex = try container.decodeIfPresent(Int.self, forKey: .currentIndex) ?? 0
     }
+
+    /// Index for sequential transition
+    var currentIndex: Int
 }

--- a/iWorkout Watch App/Resources/en.lproj/Localizable.strings
+++ b/iWorkout Watch App/Resources/en.lproj/Localizable.strings
@@ -24,3 +24,14 @@
 "Workouts" = "Workouts";
 "Add Workout" = "Add Workout";
 "Active" = "Active";
+"Transition" = "Transition";
+"Weekly" = "Weekly";
+"Sequential" = "Sequential";
+"Weekday" = "Weekday";
+"Monday" = "Monday";
+"Tuesday" = "Tuesday";
+"Wednesday" = "Wednesday";
+"Thursday" = "Thursday";
+"Friday" = "Friday";
+"Saturday" = "Saturday";
+"Sunday" = "Sunday";

--- a/iWorkout Watch App/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout Watch App/Resources/pt.lproj/Localizable.strings
@@ -24,3 +24,14 @@
 "Workouts" = "Treinos";
 "Add Workout" = "Adicionar Treino";
 "Active" = "Ativo";
+"Transition" = "Transição";
+"Weekly" = "Semanal";
+"Sequential" = "Sequencial";
+"Weekday" = "Dia da semana";
+"Monday" = "Segunda";
+"Tuesday" = "Terça";
+"Wednesday" = "Quarta";
+"Thursday" = "Quinta";
+"Friday" = "Sexta";
+"Saturday" = "Sábado";
+"Sunday" = "Domingo";

--- a/iWorkout Watch App/Workout/ViewModels/WatchWorkoutViewModel.swift
+++ b/iWorkout Watch App/Workout/ViewModels/WatchWorkoutViewModel.swift
@@ -64,4 +64,15 @@ class WatchWorkoutViewModel: ObservableObject {
             }
         }
     }
+
+    func completeWorkout() {
+        guard shared.styles.indices.contains(styleIndex) else { return }
+        var style = shared.styles[styleIndex]
+        guard style.sessions.count > 0 else { return }
+        if style.transition == .sequential {
+            style.currentIndex = (style.currentIndex + 1) % style.sessions.count
+            shared.styles[styleIndex] = style
+            shared.sendStyles(shared.styles)
+        }
+    }
 }

--- a/iWorkout Watch App/Workout/Views/SessionListView.swift
+++ b/iWorkout Watch App/Workout/Views/SessionListView.swift
@@ -4,23 +4,40 @@ import SwiftUI
 struct SessionListView: View {
     let styleIndex: Int
     @ObservedObject var shared = SharedData.shared
+    @State private var selection: Int?
 
     var body: some View {
         let style = shared.styles[styleIndex]
-        List {
+        List(selection: $selection) {
             if style.sessions.isEmpty {
                 Text("You haven't added sessions yet")
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .center)
             } else {
                 ForEach(style.sessions.indices, id: \.self) { idx in
-                    NavigationLink(style.sessions[idx].name) {
+                    NavigationLink(style.sessions[idx].name,
+                                   tag: idx,
+                                   selection: $selection) {
                         WorkoutView(styleIndex: styleIndex, sessionIndex: idx)
                     }
                 }
             }
         }
         .navigationTitle(style.name)
+        .onAppear {
+            switch style.transition {
+            case .weekly:
+                let weekday = Calendar.current.component(.weekday, from: Date())
+                let mapped = Weekday.allCases[(weekday + 5) % 7]
+                if let idx = style.sessions.firstIndex(where: { $0.weekday == mapped }) {
+                    selection = idx
+                }
+            case .sequential:
+                if style.sessions.indices.contains(style.currentIndex) {
+                    selection = style.currentIndex
+                }
+            }
+        }
     }
 }
 

--- a/iWorkout Watch App/Workout/Views/WorkoutView.swift
+++ b/iWorkout Watch App/Workout/Views/WorkoutView.swift
@@ -39,6 +39,9 @@ struct WorkoutView: View {
                 }
             }
         }
+        .onDisappear {
+            viewModel.completeWorkout()
+        }
     }
 }
 

--- a/iWorkout/Exercises/ViewModels/ExerciseListViewModel.swift
+++ b/iWorkout/Exercises/ViewModels/ExerciseListViewModel.swift
@@ -24,7 +24,8 @@ class ExerciseListViewModel: ObservableObject {
     convenience init() {
         let model = WorkoutStyleListViewModel()
         if model.styles.isEmpty {
-            let defaultStyle = WorkoutStyle(name: "Default", sessions: [WorkoutSession(name: "Session")])
+            let defaultStyle = WorkoutStyle(name: "Default",
+                                           sessions: [WorkoutSession(name: "Session")])
             model.styles = [defaultStyle]
         }
         self.init(session: model.styles[0].sessions[0]) { updated in

--- a/iWorkout/Exercises/ViewModels/WorkoutSessionViewModel.swift
+++ b/iWorkout/Exercises/ViewModels/WorkoutSessionViewModel.swift
@@ -17,8 +17,8 @@ class WorkoutSessionViewModel: ObservableObject {
         set { style.sessions = newValue }
     }
 
-    func addSession(_ name: String) {
-        style.sessions.append(WorkoutSession(name: name))
+    func addSession(_ name: String, weekday: Weekday? = nil) {
+        style.sessions.append(WorkoutSession(name: name, weekday: weekday))
     }
 
     func updateSession(_ session: WorkoutSession) {

--- a/iWorkout/Exercises/ViewModels/WorkoutStyleListViewModel.swift
+++ b/iWorkout/Exercises/ViewModels/WorkoutStyleListViewModel.swift
@@ -24,8 +24,15 @@ class WorkoutStyleListViewModel: ObservableObject {
         startExpirationTimer()
     }
 
-    func addStyle(_ name: String, isActive: Bool = false, activeUntil: Date? = nil) {
-        var newStyle = WorkoutStyle(name: name, isActive: isActive, activeUntil: activeUntil)
+    func addStyle(_ name: String,
+                  transition: DivisionTransition = .sequential,
+                  isActive: Bool = false,
+                  activeUntil: Date? = nil) {
+        var newStyle = WorkoutStyle(name: name,
+                                    sessions: [],
+                                    transition: transition,
+                                    isActive: isActive,
+                                    activeUntil: activeUntil)
         if isActive {
             for idx in styles.indices {
                 styles[idx].isActive = false

--- a/iWorkout/Exercises/Views/WorkoutSessionListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutSessionListView.swift
@@ -11,6 +11,8 @@ struct WorkoutSessionListView: View {
     @State private var editedActiveUntil = Date()
     @State private var editingSession: WorkoutSession?
     @State private var editedSessionName = ""
+    @State private var newSessionWeekday: Weekday = .monday
+    @State private var editedSessionWeekday: Weekday = .monday
 
     var body: some View {
         List {
@@ -36,6 +38,7 @@ struct WorkoutSessionListView: View {
                             Button {
                                 editingSession = session
                                 editedSessionName = session.name
+                                editedSessionWeekday = session.weekday ?? .monday
                             } label: {
                                 Label("Edit", systemImage: "pencil")
                             }
@@ -70,8 +73,17 @@ struct WorkoutSessionListView: View {
             NavigationStack {
                 Form {
                     TextField("Session name", text: $newSessionName)
+                    if viewModel.style.transition == .weekly {
+                        Picker("Weekday", selection: $newSessionWeekday) {
+                            ForEach(Weekday.allCases) { Text($0.localized).tag($0) }
+                        }
+                    }
                 }
                 .navigationTitle("New Session")
+                .onAppear {
+                    newSessionName = ""
+                    newSessionWeekday = .monday
+                }
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button { showAddSession = false } label: {
@@ -80,9 +92,11 @@ struct WorkoutSessionListView: View {
                     }
                     ToolbarItem(placement: .confirmationAction) {
                         Button {
-                            viewModel.addSession(newSessionName)
+                            viewModel.addSession(newSessionName,
+                                                weekday: viewModel.style.transition == .weekly ? newSessionWeekday : nil)
                             showAddSession = false
                             newSessionName = ""
+                            newSessionWeekday = .monday
                         } label: {
                             Label("Add", systemImage: "plus")
                         }
@@ -95,8 +109,17 @@ struct WorkoutSessionListView: View {
             NavigationStack {
                 Form {
                     TextField("Session name", text: $editedSessionName)
+                    if viewModel.style.transition == .weekly {
+                        Picker("Weekday", selection: $editedSessionWeekday) {
+                            ForEach(Weekday.allCases) { Text($0.localized).tag($0) }
+                        }
+                    }
                 }
                 .navigationTitle("Edit Session")
+                .onAppear {
+                    editedSessionName = session.name
+                    editedSessionWeekday = session.weekday ?? .monday
+                }
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button { editingSession = nil } label: {
@@ -107,6 +130,7 @@ struct WorkoutSessionListView: View {
                         Button {
                             var updated = session
                             updated.name = editedSessionName
+                            updated.weekday = viewModel.style.transition == .weekly ? editedSessionWeekday : nil
                             viewModel.updateSession(updated)
                             editingSession = nil
                         } label: {

--- a/iWorkout/Exercises/Views/WorkoutStyleListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutStyleListView.swift
@@ -9,9 +9,11 @@ struct WorkoutStyleListView: View {
     @State private var editedStyleName = ""
     @State private var editedIsActive = false
     @State private var editedActiveUntil = Date()
+    @State private var editedTransition: DivisionTransition = .sequential
 
     @State private var newStyleIsActive = false
     @State private var newStyleActiveUntil = Date()
+    @State private var newStyleTransition: DivisionTransition = .sequential
 
     var body: some View {
         NavigationStack {
@@ -41,6 +43,7 @@ struct WorkoutStyleListView: View {
                                 editedStyleName = style.name
                                 editedIsActive = style.isActive
                                 editedActiveUntil = style.activeUntil ?? Date()
+                                editedTransition = style.transition
                                 editingStyle = style
                             } label: {
                                 Label("Edit", systemImage: "pencil")
@@ -67,6 +70,9 @@ struct WorkoutStyleListView: View {
                 NavigationStack {
                     Form {
                         TextField("Style name", text: $newStyleName)
+                        Picker("Transition", selection: $newStyleTransition) {
+                            ForEach(DivisionTransition.allCases) { Text($0.localized).tag($0) }
+                        }
                         Toggle("Active", isOn: $newStyleIsActive)
                         if newStyleIsActive {
                             DatePicker("Active Until", selection: $newStyleActiveUntil, in: Date()..., displayedComponents: [.date, .hourAndMinute])
@@ -78,6 +84,7 @@ struct WorkoutStyleListView: View {
                         newStyleName = ""
                         newStyleIsActive = false
                         newStyleActiveUntil = Date()
+                        newStyleTransition = .sequential
                     }
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
@@ -87,9 +94,13 @@ struct WorkoutStyleListView: View {
                         }
                         ToolbarItem(placement: .confirmationAction) {
                             Button {
-                                model.addStyle(newStyleName, isActive: newStyleIsActive, activeUntil: newStyleIsActive ? newStyleActiveUntil : nil)
+                                model.addStyle(newStyleName,
+                                               transition: newStyleTransition,
+                                               isActive: newStyleIsActive,
+                                               activeUntil: newStyleIsActive ? newStyleActiveUntil : nil)
                                 showAddStyle = false
                                 newStyleName = ""
+                                newStyleTransition = .sequential
                                 newStyleIsActive = false
                                 newStyleActiveUntil = Date()
                             } label: {
@@ -104,6 +115,9 @@ struct WorkoutStyleListView: View {
                 NavigationStack {
                     Form {
                         TextField("Style name", text: $editedStyleName)
+                        Picker("Transition", selection: $editedTransition) {
+                            ForEach(DivisionTransition.allCases) { Text($0.localized).tag($0) }
+                        }
                         Toggle("Active", isOn: $editedIsActive)
                         if editedIsActive {
                             DatePicker("Active Until", selection: $editedActiveUntil, in: Date()..., displayedComponents: [.date, .hourAndMinute])
@@ -115,6 +129,7 @@ struct WorkoutStyleListView: View {
                         editedStyleName = style.name
                         editedIsActive = style.isActive
                         editedActiveUntil = style.activeUntil ?? Date()
+                        editedTransition = style.transition
                     }
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
@@ -124,13 +139,13 @@ struct WorkoutStyleListView: View {
                         }
                         ToolbarItem(placement: .confirmationAction) {
                             Button {
-                                if let idx = model.styles.firstIndex(of: style) {
-                                    model.updateStyle(WorkoutStyle(id: style.id,
-                                                                   name: editedStyleName,
-                                                                   sessions: style.sessions,
-                                                                   isActive: editedIsActive,
-                                                                   activeUntil: editedIsActive ? editedActiveUntil : nil))
-                                }
+                                model.updateStyle(WorkoutStyle(id: style.id,
+                                                               name: editedStyleName,
+                                                               sessions: style.sessions,
+                                                               transition: editedTransition,
+                                                               isActive: editedIsActive,
+                                                               activeUntil: editedIsActive ? editedActiveUntil : nil,
+                                                               currentIndex: style.currentIndex))
                                 editingStyle = nil
                             } label: {
                                 Label("Save", systemImage: "checkmark")

--- a/iWorkout/Resources/en.lproj/Localizable.strings
+++ b/iWorkout/Resources/en.lproj/Localizable.strings
@@ -34,3 +34,14 @@
 "Active Until" = "Active Until";
 "Active" = "Active";
 "New Style" = "New Style";
+"Transition" = "Transition";
+"Weekly" = "Weekly";
+"Sequential" = "Sequential";
+"Weekday" = "Weekday";
+"Monday" = "Monday";
+"Tuesday" = "Tuesday";
+"Wednesday" = "Wednesday";
+"Thursday" = "Thursday";
+"Friday" = "Friday";
+"Saturday" = "Saturday";
+"Sunday" = "Sunday";

--- a/iWorkout/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout/Resources/pt.lproj/Localizable.strings
@@ -35,3 +35,14 @@
 "Active Until" = "Ativo até";
 "Active" = "Ativo";
 "New Style" = "Novo Treino";
+"Transition" = "Transição";
+"Weekly" = "Semanal";
+"Sequential" = "Sequencial";
+"Weekday" = "Dia da semana";
+"Monday" = "Segunda";
+"Tuesday" = "Terça";
+"Wednesday" = "Quarta";
+"Thursday" = "Quinta";
+"Friday" = "Sexta";
+"Saturday" = "Sábado";
+"Sunday" = "Domingo";


### PR DESCRIPTION
## Summary
- enable sequential or weekly division transitions
- track weekdays for sessions
- let styles store the transition type and current index
- choose transitions and weekdays when editing styles and sessions
- update Watch views to auto-open sessions based on transition
- localize new strings

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850873596c8833180e90e642db6a2e4