### PR TITLE
Unify workout style edit form

### DIFF
--- a/Shared/UIComponents/WorkoutStyleForm.swift
+++ b/Shared/UIComponents/WorkoutStyleForm.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct WorkoutStyleForm: View {
+    @Binding var name: String
+    @Binding var transition: DivisionTransition
+    @Binding var isActive: Bool
+    @Binding var activeUntil: Date
+
+    var body: some View {
+        Form {
+            TextField("Style name", text: $name)
+            Picker("Transition", selection: $transition) {
+                ForEach(DivisionTransition.allCases) { Text($0.localized).tag($0) }
+            }
+            Toggle("Active", isOn: $isActive)
+            if isActive {
+                DatePicker("Active Until", selection: $activeUntil, in: Date()..., displayedComponents: [.date, .hourAndMinute])
+            }
+        }
+        .animation(.default, value: isActive)
+    }
+}

--- a/iWorkout/Exercises/Views/WorkoutSessionListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutSessionListView.swift
@@ -9,6 +9,7 @@ struct WorkoutSessionListView: View {
     @State private var editedStyleName = ""
     @State private var editedIsActive = false
     @State private var editedActiveUntil = Date()
+    @State private var editedTransition: DivisionTransition = .sequential
     @State private var editingSession: WorkoutSession?
     @State private var editedSessionName = ""
     @State private var newSessionWeekday: Weekday = .monday
@@ -56,6 +57,7 @@ struct WorkoutSessionListView: View {
                     editedStyleName = viewModel.style.name
                     editedIsActive = viewModel.style.isActive
                     editedActiveUntil = viewModel.style.activeUntil ?? Date()
+                    editedTransition = viewModel.style.transition
                     showEditStyle = true
                 }
 
@@ -143,14 +145,10 @@ struct WorkoutSessionListView: View {
         }
         .sheet(isPresented: $showEditStyle) {
             NavigationStack {
-                Form {
-                    TextField("Style name", text: $editedStyleName)
-                    Toggle("Active", isOn: $editedIsActive)
-                    if editedIsActive {
-                        DatePicker("Active Until", selection: $editedActiveUntil, in: Date()..., displayedComponents: [.date, .hourAndMinute])
-                    }
-                }
-                .animation(.default, value: editedIsActive)
+                WorkoutStyleForm(name: $editedStyleName,
+                                 transition: $editedTransition,
+                                 isActive: $editedIsActive,
+                                 activeUntil: $editedActiveUntil)
                 .navigationTitle("Edit Style")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
@@ -161,6 +159,7 @@ struct WorkoutSessionListView: View {
                     ToolbarItem(placement: .confirmationAction) {
                         Button {
                             viewModel.style.name = editedStyleName
+                            viewModel.style.transition = editedTransition
                             viewModel.style.isActive = editedIsActive
                             viewModel.style.activeUntil = editedIsActive ? editedActiveUntil : nil
                             showEditStyle = false

--- a/iWorkout/Exercises/Views/WorkoutStyleListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutStyleListView.swift
@@ -68,17 +68,10 @@ struct WorkoutStyleListView: View {
             }
             .sheet(isPresented: $showAddStyle) {
                 NavigationStack {
-                    Form {
-                        TextField("Style name", text: $newStyleName)
-                        Picker("Transition", selection: $newStyleTransition) {
-                            ForEach(DivisionTransition.allCases) { Text($0.localized).tag($0) }
-                        }
-                        Toggle("Active", isOn: $newStyleIsActive)
-                        if newStyleIsActive {
-                            DatePicker("Active Until", selection: $newStyleActiveUntil, in: Date()..., displayedComponents: [.date, .hourAndMinute])
-                        }
-                    }
-                    .animation(.default, value: newStyleIsActive)
+                    WorkoutStyleForm(name: $newStyleName,
+                                     transition: $newStyleTransition,
+                                     isActive: $newStyleIsActive,
+                                     activeUntil: $newStyleActiveUntil)
                     .navigationTitle("New Style")
                     .onAppear {
                         newStyleName = ""
@@ -113,17 +106,10 @@ struct WorkoutStyleListView: View {
             }
             .sheet(item: $editingStyle) { style in
                 NavigationStack {
-                    Form {
-                        TextField("Style name", text: $editedStyleName)
-                        Picker("Transition", selection: $editedTransition) {
-                            ForEach(DivisionTransition.allCases) { Text($0.localized).tag($0) }
-                        }
-                        Toggle("Active", isOn: $editedIsActive)
-                        if editedIsActive {
-                            DatePicker("Active Until", selection: $editedActiveUntil, in: Date()..., displayedComponents: [.date, .hourAndMinute])
-                        }
-                    }
-                    .animation(.default, value: editedIsActive)
+                    WorkoutStyleForm(name: $editedStyleName,
+                                     transition: $editedTransition,
+                                     isActive: $editedIsActive,
+                                     activeUntil: $editedActiveUntil)
                     .navigationTitle("Edit Style")
                     .onAppear {
                         editedStyleName = style.name


### PR DESCRIPTION
## Summary
- reuse a single `WorkoutStyleForm` component for editing/adding workout styles
- show the same edit form from both list screens

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build`

------
https://chatgpt.com/codex/tasks/task_e_6850a38a8a8883318d839d08cbbab5bd