### PR TITLE
Update session progression labeling

### DIFF
--- a/Shared/Entities/DivisionTransition.swift
+++ b/Shared/Entities/DivisionTransition.swift
@@ -9,9 +9,9 @@ enum DivisionTransition: String, Codable, CaseIterable, Identifiable {
     var localized: String {
         switch self {
         case .weekly:
-            return NSLocalizedString("Weekly", comment: "")
+            return NSLocalizedString("Fixed to Weekdays", comment: "")
         case .sequential:
-            return NSLocalizedString("Sequential", comment: "")
+            return NSLocalizedString("One After Another", comment: "")
         }
     }
 }

--- a/Shared/UIComponents/WorkoutStyleForm.swift
+++ b/Shared/UIComponents/WorkoutStyleForm.swift
@@ -9,13 +9,19 @@ struct WorkoutStyleForm: View {
     var body: some View {
         Form {
             TextField("Style name", text: $name)
-            Picker("Session Progression", selection: $transition) {
-                ForEach(DivisionTransition.allCases) { Text($0.localized).tag($0) }
-            }
-            .help(Text("Session Progression Help"))
             Toggle("Active", isOn: $isActive)
             if isActive {
                 DatePicker("Active Until", selection: $activeUntil, in: Date()..., displayedComponents: [.date, .hourAndMinute])
+            }
+            Section(header: Text("About Sessions")) {
+                Picker("Session Progression", selection: $transition) {
+                    ForEach(DivisionTransition.allCases) { Text($0.localized).tag($0) }
+                }
+                .help(Text("Session Progression Help"))
+
+                Text("Session Progression Help")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
             }
         }
         .animation(.default, value: isActive)

--- a/Shared/UIComponents/WorkoutStyleForm.swift
+++ b/Shared/UIComponents/WorkoutStyleForm.swift
@@ -9,9 +9,10 @@ struct WorkoutStyleForm: View {
     var body: some View {
         Form {
             TextField("Style name", text: $name)
-            Picker("Transition", selection: $transition) {
+            Picker("Session Progression", selection: $transition) {
                 ForEach(DivisionTransition.allCases) { Text($0.localized).tag($0) }
             }
+            .help(Text("Session Progression Help"))
             Toggle("Active", isOn: $isActive)
             if isActive {
                 DatePicker("Active Until", selection: $activeUntil, in: Date()..., displayedComponents: [.date, .hourAndMinute])

--- a/iWorkout Watch App/Resources/en.lproj/Localizable.strings
+++ b/iWorkout Watch App/Resources/en.lproj/Localizable.strings
@@ -24,9 +24,10 @@
 "Workouts" = "Workouts";
 "Add Workout" = "Add Workout";
 "Active" = "Active";
-"Transition" = "Transition";
-"Weekly" = "Weekly";
-"Sequential" = "Sequential";
+"Session Progression" = "Session Progression";
+"Fixed to Weekdays" = "Fixed to Weekdays";
+"One After Another" = "One After Another";
+"Session Progression Help" = "How sessions progress:\nChoose how the app should determine your next workout.\n• One After Another: Moves to the next session after completion.\n• Fixed to Weekdays: Each session is tied to a specific day (e.g., Leg Day on Monday).";
 "Weekday" = "Weekday";
 "Monday" = "Monday";
 "Tuesday" = "Tuesday";

--- a/iWorkout Watch App/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout Watch App/Resources/pt.lproj/Localizable.strings
@@ -24,9 +24,10 @@
 "Workouts" = "Treinos";
 "Add Workout" = "Adicionar Treino";
 "Active" = "Ativo";
-"Transition" = "Transição";
-"Weekly" = "Semanal";
-"Sequential" = "Sequencial";
+"Session Progression" = "Progressão das Sessões";
+"Fixed to Weekdays" = "Fixado aos Dias da Semana";
+"One After Another" = "Uma Após a Outra";
+"Session Progression Help" = "Como as sessões progridem:\nEscolha como o app deve determinar seu próximo treino.\n• Uma Após a Outra: Avança para a próxima sessão após concluir.\n• Fixado aos Dias da Semana: Cada sessão é vinculada a um dia específico (ex.: Treino de pernas na segunda-feira).";
 "Weekday" = "Dia da semana";
 "Monday" = "Segunda";
 "Tuesday" = "Terça";

--- a/iWorkout/Exercises/Views/ExerciseListView.swift
+++ b/iWorkout/Exercises/Views/ExerciseListView.swift
@@ -31,15 +31,17 @@ struct ExerciseListView: View {
                                 selectedExerciseId = id
                             })
         .toolbar {
-            ToolbarItemGroup(placement: .bottomBar) {
+            ToolbarItemGroup {
                 Button("Edit Session") {
                     sessionName = model.session.name
                     sessionWeekday = model.session.weekday ?? .monday
                     showEditSession = true
                 }
+            }
+            ToolbarItemGroup(placement: .bottomBar) {
                 Spacer()
                 Button { showAddExercise = true } label: {
-                    Label("Add Exercise", systemImage: "plus")
+                    Label("Add Exercise", systemImage: "checkmark")
                 }
                 .bold()
             }

--- a/iWorkout/Exercises/Views/WorkoutSessionListView.swift
+++ b/iWorkout/Exercises/Views/WorkoutSessionListView.swift
@@ -53,7 +53,7 @@ struct WorkoutSessionListView: View {
         }
         .navigationTitle(viewModel.style.name)
         .toolbar {
-            ToolbarItemGroup(placement: .bottomBar) {
+            ToolbarItemGroup {
                 Button("Edit Workout") {
                     editedStyleName = viewModel.style.name
                     editedIsActive = viewModel.style.isActive
@@ -61,7 +61,8 @@ struct WorkoutSessionListView: View {
                     editedTransition = viewModel.style.transition
                     showEditStyle = true
                 }
-
+            }
+            ToolbarItemGroup(placement: .bottomBar) {
                 Spacer()
 
                 Button {
@@ -101,7 +102,7 @@ struct WorkoutSessionListView: View {
                             newSessionName = ""
                             newSessionWeekday = .monday
                         } label: {
-                            Label("Add", systemImage: "plus")
+                            Label("Add", systemImage: "checkmark")
                         }
                         .disabled(newSessionName.isEmpty)
                     }

--- a/iWorkout/Resources/en.lproj/Localizable.strings
+++ b/iWorkout/Resources/en.lproj/Localizable.strings
@@ -34,9 +34,10 @@
 "Active Until" = "Active Until";
 "Active" = "Active";
 "New Style" = "New Style";
-"Transition" = "Transition";
-"Weekly" = "Weekly";
-"Sequential" = "Sequential";
+"Session Progression" = "Session Progression";
+"Fixed to Weekdays" = "Fixed to Weekdays";
+"One After Another" = "One After Another";
+"Session Progression Help" = "How sessions progress:\nChoose how the app should determine your next workout.\n• One After Another: Moves to the next session after completion.\n• Fixed to Weekdays: Each session is tied to a specific day (e.g., Leg Day on Monday).";
 "Weekday" = "Weekday";
 "Monday" = "Monday";
 "Tuesday" = "Tuesday";

--- a/iWorkout/Resources/en.lproj/Localizable.strings
+++ b/iWorkout/Resources/en.lproj/Localizable.strings
@@ -34,7 +34,8 @@
 "Active Until" = "Active Until";
 "Active" = "Active";
 "New Style" = "New Style";
-"Session Progression" = "Session Progression";
+"About Sessions" = "About Sessions";
+"Session Progression" = "Progression";
 "Fixed to Weekdays" = "Fixed to Weekdays";
 "One After Another" = "One After Another";
 "Session Progression Help" = "How sessions progress:\nChoose how the app should determine your next workout.\n• One After Another: Moves to the next session after completion.\n• Fixed to Weekdays: Each session is tied to a specific day (e.g., Leg Day on Monday).";

--- a/iWorkout/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout/Resources/pt.lproj/Localizable.strings
@@ -22,7 +22,7 @@
 "Sessions" = "Divisões";
 "Workouts" = "Treinos";
 "Edit Style" = "Editar Treino";
-"Edit Session" = "Editar Sessão";
+"Edit Session" = "Editar Divisão";
 "New Exercise" = "Novo Exercício";
 "Send to Apple Watch?" = "Enviar para o Apple Watch?";
 "Send" = "Enviar";
@@ -35,10 +35,11 @@
 "Active Until" = "Ativo até";
 "Active" = "Ativo";
 "New Style" = "Novo Treino";
-"Session Progression" = "Progressão das Sessões";
+"About Sessions" = "Sobre as Divisões";
+"Session Progression" = "Progressão";
 "Fixed to Weekdays" = "Fixado aos Dias da Semana";
 "One After Another" = "Uma Após a Outra";
-"Session Progression Help" = "Como as sessões progridem:\nEscolha como o app deve determinar seu próximo treino.\n• Uma Após a Outra: Avança para a próxima sessão após concluir.\n• Fixado aos Dias da Semana: Cada sessão é vinculada a um dia específico (ex.: Treino de pernas na segunda-feira).";
+"Session Progression Help" = "Como as divisões progridem:\nEscolha como o app deve determinar seu próximo treino.\n• Uma Após a Outra: Avança para a próxima divisão após concluir.\n• Fixado aos Dias da Semana: Cada divisão é vinculada a um dia específico (ex.: Treino de pernas na segunda-feira).";
 "Weekday" = "Dia da semana";
 "Monday" = "Segunda";
 "Tuesday" = "Terça";

--- a/iWorkout/Resources/pt.lproj/Localizable.strings
+++ b/iWorkout/Resources/pt.lproj/Localizable.strings
@@ -35,9 +35,10 @@
 "Active Until" = "Ativo até";
 "Active" = "Ativo";
 "New Style" = "Novo Treino";
-"Transition" = "Transição";
-"Weekly" = "Semanal";
-"Sequential" = "Sequencial";
+"Session Progression" = "Progressão das Sessões";
+"Fixed to Weekdays" = "Fixado aos Dias da Semana";
+"One After Another" = "Uma Após a Outra";
+"Session Progression Help" = "Como as sessões progridem:\nEscolha como o app deve determinar seu próximo treino.\n• Uma Após a Outra: Avança para a próxima sessão após concluir.\n• Fixado aos Dias da Semana: Cada sessão é vinculada a um dia específico (ex.: Treino de pernas na segunda-feira).";
 "Weekday" = "Dia da semana";
 "Monday" = "Segunda";
 "Tuesday" = "Terça";


### PR DESCRIPTION
## Summary
- rename transition picker to Session Progression
- relabel options to Fixed to Weekdays and One After Another
- add help popover for the progression picker
- localize new labels and help text in English and Portuguese

## Testing
- `xcodebuild -project iWorkout.xcodeproj -scheme iWorkout CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project iWorkout.xcodeproj -scheme "iWorkout Watch App" CODE_SIGNING_ALLOWED=NO build`


------
https://chatgpt.com/codex/tasks/task_e_6851f43de87483318e637d919b402620